### PR TITLE
Handle generic trajectory arguments on the ROS client trajectory follower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
       env: TRAVIS_PYTHON_VERSION=3.7
 
 install:
+  - python -m ensurepip
   - pip install cython --install-option="--no-cython-compile"
   - pip install --no-cache-dir -r requirements-dev.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
       before_install:
         - choco install python2 vcredist2008
         - choco install --ignore-dependencies vcpython27
-        - pip install pypiwin32
       env:
         - PATH=/c/Python27:/c/Python27/Scripts:$PATH
         - TRAVIS_PYTHON_VERSION=2.7
@@ -18,7 +17,6 @@ matrix:
       language: shell
       before_install:
         - choco install python
-        - pip install pypiwin32
       env:
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
         - TRAVIS_PYTHON_VERSION=3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ matrix:
 
 install:
   - python -m ensurepip
-  - pip install cython --install-option="--no-cython-compile"
-  - pip install --no-cache-dir -r requirements-dev.txt
+  - python -m pip install cython --install-option="--no-cython-compile"
+  - python -m pip install --no-cache-dir -r requirements-dev.txt
 
 script:
   - python -c "import compas_fab"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ matrix:
       env:
         - PATH=/c/Python27:/c/Python27/Scripts:$PATH
         - TRAVIS_PYTHON_VERSION=2.7
-    - name: "Python 3.8: Windows"
+    - name: "Python 3.7: Windows"
       os: windows
       language: shell
       before_install:
-        - choco install python3
+        - choco install python3 --version=3.7.4
       env:
-        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
-        - TRAVIS_PYTHON_VERSION=3.8
+        - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+        - TRAVIS_PYTHON_VERSION=3.7
     - name: "Python 3.7: Xenial Linux"
       python: 3.7
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       os: windows
       language: shell
       before_install:
-        - choco install python
+        - choco install python3
       env:
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
         - TRAVIS_PYTHON_VERSION=3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ matrix:
       env:
         - PATH=/c/Python27:/c/Python27/Scripts:$PATH
         - TRAVIS_PYTHON_VERSION=2.7
-    - name: "Python 3.7: Windows"
+    - name: "Python 3.8: Windows"
       os: windows
       language: shell
       before_install:
         - choco install python3
       env:
-        - PATH=/c/Python37:/c/Python37/Scripts:$PATH
-        - TRAVIS_PYTHON_VERSION=3.7
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        - TRAVIS_PYTHON_VERSION=3.8
     - name: "Python 3.7: Xenial Linux"
       python: 3.7
       dist: xenial
@@ -32,9 +32,8 @@ matrix:
       env: TRAVIS_PYTHON_VERSION=3.7
 
 install:
-  - python -m ensurepip
-  - python -m pip install cython --install-option="--no-cython-compile"
-  - python -m pip install --no-cache-dir -r requirements-dev.txt
+  - pip install cython --install-option="--no-cython-compile"
+  - pip install --no-cache-dir -r requirements-dev.txt
 
 script:
   - python -c "import compas_fab"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Unreleased
 **Removed**
 
 * Removed ``compas_fab.sensors.baumer.PosConCM.get_live_monitor_data()``
+* Removed non-implemented methods from ``compas_fab.robots.Robot``: ``send_frame``, ``send_configuration``, ``send_trajectory``
 
 0.6.0
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,17 +12,16 @@ Unreleased
 
 **Changed**
 
+* Fixed Python 2 vs Python 3 incompatibilities in ``compas_fab.sensors`` module
 * Changed example for loading PosConCM (includes parity argument, differs from PosCon3D)
 * Changed format ``compas_fab.sensors.baumer.PosConCM.set_flex_mount()``
 * Changed tasks.py to run ``invoke test``
-* Fixed Python 2 vs Python 3 incompatibilities
-
+* ROS client: changed joint trajectory follower (``follow_joint_trajectory``) to support generic ``JointTrajectory`` arguments.
 
 **Added**
 
 * Added ``compas_fab.sensors.baumer.PosCon3D.reset()``
 * Added ``compas_fab.sensors.baumer.PosConCM.reset()``
-
 
 **Removed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,13 +16,16 @@ Unreleased
 * Changed example for loading PosConCM (includes parity argument, differs from PosCon3D)
 * Changed format ``compas_fab.sensors.baumer.PosConCM.set_flex_mount()``
 * Changed tasks.py to run ``invoke test``
+* Renamed ``compas_fab.backends.CancellableTask`` to ``compas_fab.backends.CancellableFutureResult``
 * ROS client: changed joint trajectory follower (``follow_joint_trajectory``) to support generic ``JointTrajectory`` arguments.
+* ROS client: changed return type of trajectory execution methods to ``CancellableFutureResult``
 
 **Added**
 
 * Added ``compas_fab.sensors.baumer.PosCon3D.reset()``
 * Added ``compas_fab.sensors.baumer.PosConCM.reset()``
 * ROS client: added support for MoveIt! execution action via `client.execute_joint_trajectory`.
+* Added ``compas_fab.backends.FutureResult`` class to deal with long-running async tasks
 
 **Removed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Unreleased
 
 * Added ``compas_fab.sensors.baumer.PosCon3D.reset()``
 * Added ``compas_fab.sensors.baumer.PosConCM.reset()``
+* ROS client: added support for MoveIt! execution action via `client.execute_joint_trajectory`.
 
 **Removed**
 

--- a/src/compas_fab/backends/__init__.py
+++ b/src/compas_fab/backends/__init__.py
@@ -26,14 +26,15 @@ ROS
     RosClient
     RosFileServerLoader
 
-Tasks
------
+Long-running tasks
+------------------
 
 .. autosummary::
     :toctree: generated/
     :nosignatures:
 
-    CancellableTask
+    FutureResult
+    CancellableFutureResult
 
 Exceptions
 ----------

--- a/src/compas_fab/backends/ros/messages/control_msgs.py
+++ b/src/compas_fab/backends/ros/messages/control_msgs.py
@@ -12,21 +12,21 @@ class JointTolerance(ROSmsg):
     """
     def __init__(self, name="", position=0., velocity=0., acceleration=0.):
         self.name = name
-        self.position = position # in radians or meters (for a revolute or prismatic joint, respectively)
-        self.velocity = velocity  # in rad/sec or m/sec
-        self.acceleration = acceleration # in rad/sec^2 or m/sec^2
+        self.position = position          # in radians or meters (for a revolute or prismatic joint, respectively)
+        self.velocity = velocity          # in rad/sec or m/sec
+        self.acceleration = acceleration  # in rad/sec^2 or m/sec^2
 
 
 class FollowJointTrajectoryGoal(ROSmsg):
     """http://docs.ros.org/fuerte/api/control_msgs/html/msg/FollowJointTrajectoryGoal.html
     """
 
-    def __init__(self, trajectory=None, path_tolerance=None, 
+    def __init__(self, trajectory=None, path_tolerance=None,
                  goal_tolerance=None, goal_time_tolerance=None):
-        self.trajectory = trajectory if trajectory else JointTrajectory() #trajectory_msgs/JointTrajectory 
-        self.path_tolerance = path_tolerance if path_tolerance else []#control_msgs/JointTolerance[] 
-        self.goal_tolerance = goal_tolerance if goal_tolerance else [] #control_msgs/JointTolerance[] 
-        self.goal_time_tolerance = goal_time_tolerance if goal_time_tolerance else Time(secs=1.)
+        self.trajectory = trajectory or JointTrajectory()  # trajectory_msgs/JointTrajectory
+        self.path_tolerance = path_tolerance or []         # control_msgs/JointTolerance[]
+        self.goal_tolerance = goal_tolerance or []         # control_msgs/JointTolerance[]
+        self.goal_time_tolerance = goal_time_tolerance or Time(secs=1.)
 
 
 class FollowJointTrajectoryActionGoal(ROSmsg):
@@ -34,9 +34,9 @@ class FollowJointTrajectoryActionGoal(ROSmsg):
     """
 
     def __init__(self, header=None, goal_id=None, goal=None):
-        self.header = header if header else Header()
-        self.goal_id = goal_id if goal_id else GoalID() #actionlib_msgs/GoalID goal_id
-        self.goal = goal if goal else FollowJointTrajectoryGoal() # FollowJointTrajectoryGoal goal
+        self.header = header or Header()
+        self.goal_id = goal_id or GoalID()  # actionlib_msgs/GoalID goal_id
+        self.goal = goal or FollowJointTrajectoryGoal()  # FollowJointTrajectoryGoal goal
 
 
 class FollowJointTrajectoryFeedback(ROSmsg):
@@ -44,20 +44,20 @@ class FollowJointTrajectoryFeedback(ROSmsg):
     """
     def __init__(self, header=None, joint_names=None, desired=None, actual=None,
                  error=None):
-        self.header = header if header else Header()
-        self.joint_names = joint_names if joint_names else []
-        self.desired = desired if desired else JointTrajectoryPoint()
-        self.actual = actual if actual else JointTrajectoryPoint()
-        self.error = error if error else JointTrajectoryPoint()
+        self.header = header or Header()
+        self.joint_names = joint_names or []
+        self.desired = desired or JointTrajectoryPoint()
+        self.actual = actual or JointTrajectoryPoint()
+        self.error = error or JointTrajectoryPoint()
 
 
 class FollowJointTrajectoryActionFeedback(ROSmsg):
     """http://docs.ros.org/fuerte/api/control_msgs/html/msg/FollowJointTrajectoryActionFeedback.html
     """
     def __init__(self, header=None, status=None, feedback=None):
-        self.header = header if header else Header()
-        self.status = status if status else GoalStatus()
-        self.feedback = feedback if feedback else FollowJointTrajectoryFeedback()
+        self.header = header or Header()
+        self.status = status or GoalStatus()
+        self.feedback = feedback or FollowJointTrajectoryFeedback()
 
 
 class FollowJointTrajectoryResult(ROSmsg):
@@ -74,7 +74,7 @@ class FollowJointTrajectoryResult(ROSmsg):
     def __init__(self, error_code=0, error_string=""):
         self.error_code = error_code
         self.error_string = error_string
-    
+
     @classmethod
     def from_msg(cls, msg):
         error_code = msg['error_code']
@@ -93,14 +93,13 @@ class FollowJointTrajectoryActionResult(ROSmsg):
     """http://docs.ros.org/fuerte/api/control_msgs/html/msg/FollowJointTrajectoryActionResult.html
     """
     def __init__(self, header=None, status=None, result=None):
-        self.header = header if header else Header()
-        self.status = status if status else GoalStatus()
-        self.result = result if result else FollowJointTrajectoryResult()
-    
+        self.header = header or Header()
+        self.status = status or GoalStatus()
+        self.result = result or FollowJointTrajectoryResult()
+
     @classmethod
     def from_msg(cls, msg):
         header = Header.from_msg(msg['header'])
         status = GoalStatus.from_msg(msg['status'])
         result = FollowJointTrajectoryResult.from_msg(msg['result'])
         return cls(header, status, result)
-

--- a/src/compas_fab/backends/ros/messages/moveit_msgs.py
+++ b/src/compas_fab/backends/ros/messages/moveit_msgs.py
@@ -1,21 +1,21 @@
 from __future__ import absolute_import
 
-from compas_fab.backends.ros.messages.std_msgs import ROSmsg
-from compas_fab.backends.ros.messages.std_msgs import Header
 from compas_fab.backends.ros.messages.geometry_msgs import Point
 from compas_fab.backends.ros.messages.geometry_msgs import Pose
 from compas_fab.backends.ros.messages.geometry_msgs import PoseStamped
-from compas_fab.backends.ros.messages.geometry_msgs import Vector3
 from compas_fab.backends.ros.messages.geometry_msgs import Quaternion
-from compas_fab.backends.ros.messages.shape_msgs import SolidPrimitive
-from compas_fab.backends.ros.messages.shape_msgs import Plane
-from compas_fab.backends.ros.messages.shape_msgs import Mesh
-from compas_fab.backends.ros.messages.sensor_msgs import JointState
-from compas_fab.backends.ros.messages.sensor_msgs import MultiDOFJointState
-from compas_fab.backends.ros.messages.trajectory_msgs import JointTrajectory
-from compas_fab.backends.ros.messages.trajectory_msgs import MultiDOFJointTrajectory
+from compas_fab.backends.ros.messages.geometry_msgs import Vector3
 from compas_fab.backends.ros.messages.object_recognition_msgs import ObjectType
 from compas_fab.backends.ros.messages.octomap_msgs import OctomapWithPose
+from compas_fab.backends.ros.messages.sensor_msgs import JointState
+from compas_fab.backends.ros.messages.sensor_msgs import MultiDOFJointState
+from compas_fab.backends.ros.messages.shape_msgs import Mesh
+from compas_fab.backends.ros.messages.shape_msgs import Plane
+from compas_fab.backends.ros.messages.shape_msgs import SolidPrimitive
+from compas_fab.backends.ros.messages.std_msgs import Header
+from compas_fab.backends.ros.messages.std_msgs import ROSmsg
+from compas_fab.backends.ros.messages.trajectory_msgs import JointTrajectory
+from compas_fab.backends.ros.messages.trajectory_msgs import MultiDOFJointTrajectory
 
 
 class CollisionObject(ROSmsg):
@@ -255,23 +255,25 @@ class PlannerParams(ROSmsg):
     """
 
     def __init__(self, keys=None, values=None, descriptions=None):
-        self.keys = keys if keys else [] # parameter names (same size as values)
-        self.values = values if values else [] # parameter values (same size as keys)
-        self.descriptions = descriptions if descriptions else [] # parameter description (can be empty)
+        self.keys = keys or []                  # parameter names (same size as values)
+        self.values = values or []              # parameter values (same size as keys)
+        self.descriptions = descriptions or []  # parameter description (can be empty)
+
 
 class WorkspaceParameters(ROSmsg):
     """http://docs.ros.org/kinetic/api/moveit_msgs/html/msg/WorkspaceParameters.html
     """
-    def __init__(self, header=Header(), min_corner=Vector3(-1000,-1000,-1000), max_corner=Vector3(1000,1000,1000)):
+    def __init__(self, header=Header(), min_corner=Vector3(-1000, -1000, -1000), max_corner=Vector3(1000, 1000, 1000)):
         self.header = header
         self.min_corner = min_corner
         self.max_corner = max_corner
+
 
 class TrajectoryConstraints(ROSmsg):
     """http://docs.ros.org/kinetic/api/moveit_msgs/html/msg/TrajectoryConstraints.html
     """
     def __init__(self, constraints=None):
-        self.constraints = constraints if constraints else [] #Constraints[]
+        self.constraints = constraints or []  # Constraints[]
 
 
 class JointConstraint(ROSmsg):
@@ -291,21 +293,23 @@ class JointConstraint(ROSmsg):
         c = joint_constraint
         return cls(c.joint_name, c.value, c.tolerance, c.tolerance, c.weight)
 
+
 class VisibilityConstraint(ROSmsg):
     """http://docs.ros.org/kinetic/api/moveit_msgs/html/msg/VisibilityConstraint.html
     """
     def __init__(self):
         raise NotImplementedError
 
+
 class BoundingVolume(ROSmsg):
     """http://docs.ros.org/kinetic/api/moveit_msgs/html/msg/BoundingVolume.html
     """
     def __init__(self, primitives=None, primitive_poses=None, meshes=None,
                  mesh_poses=None):
-        self.primitives = primitives if primitives else [] #shape_msgs/SolidPrimitive[]
-        self.primitive_poses = primitive_poses if primitive_poses else [] #geometry_msgs/Pose[]
-        self.meshes = meshes if meshes else [] #shape_msgs/Mesh[]
-        self.mesh_poses = mesh_poses if mesh_poses else [] #geometry_msgs/Pose[]
+        self.primitives = primitives or []            # shape_msgs/SolidPrimitive[]
+        self.primitive_poses = primitive_poses or []  # geometry_msgs/Pose[]
+        self.meshes = meshes or []                    # shape_msgs/Mesh[]
+        self.mesh_poses = mesh_poses or []            # geometry_msgs/Pose[]
 
     @classmethod
     def from_box(cls, box):
@@ -360,16 +364,17 @@ class BoundingVolume(ROSmsg):
         else:
             raise NotImplementedError
 
+
 class PositionConstraint(ROSmsg):
     """http://docs.ros.org/kinetic/api/moveit_msgs/html/msg/PositionConstraint.html
     """
     def __init__(self, header=None, link_name=None, target_point_offset=None,
                  constraint_region=None, weight=None):
-        self.header = header if header else Header()
-        self.link_name = link_name if link_name else ""
-        self.target_point_offset = target_point_offset if target_point_offset else Vector3(0.,0.,0.) # geometry_msgs/Vector3
-        self.constraint_region = constraint_region if constraint_region else BoundingVolume() # moveit_msgs/BoundingVolume
-        self.weight = float(weight) if weight else 1.
+        self.header = header or Header()
+        self.link_name = link_name or ""
+        self.target_point_offset = target_point_offset or Vector3(0., 0., 0.)  # geometry_msgs/Vector3
+        self.constraint_region = constraint_region or BoundingVolume()         # moveit_msgs/BoundingVolume
+        self.weight = float(weight) or 1.
 
     @classmethod
     def from_position_constraint(cls, header, position_constraint):
@@ -377,6 +382,7 @@ class PositionConstraint(ROSmsg):
         """
         constraint_region = BoundingVolume.from_bounding_volume(position_constraint.bounding_volume)
         return cls(header, position_constraint.link_name, None, constraint_region, position_constraint.weight)
+
 
 class OrientationConstraint(ROSmsg):
     """http://docs.ros.org/kinetic/api/moveit_msgs/html/msg/OrientationConstraint.html
@@ -393,9 +399,9 @@ class OrientationConstraint(ROSmsg):
         the z-axis by an angle of 6.3 radians, whereas the z-axis can only change
         by 0.01.
         """
-        self.header = header if header else Header()
-        self.orientation = orientation or Quaternion()#geometry_msgs/Quaternion
-        self.link_name = link_name if link_name else ""
+        self.header = header or Header()
+        self.orientation = orientation or Quaternion()  # geometry_msgs/Quaternion
+        self.link_name = link_name or ""
         self.absolute_x_axis_tolerance = float(absolute_x_axis_tolerance)
         self.absolute_y_axis_tolerance = float(absolute_y_axis_tolerance)
         self.absolute_z_axis_tolerance = float(absolute_z_axis_tolerance)
@@ -449,7 +455,7 @@ class PlanningSceneComponents(ROSmsg):
         return ''
 
 
-class  AllowedCollisionMatrix(ROSmsg):
+class AllowedCollisionMatrix(ROSmsg):
     """http://docs.ros.org/melodic/api/moveit_msgs/html/msg/AllowedCollisionMatrix.html
     """
     def __init__(self, entry_names=None, entry_values=None, default_entry_names=None, default_entry_values=None):
@@ -481,29 +487,16 @@ class PlanningScene(ROSmsg):
                  fixed_frame_transforms=None, allowed_collision_matrix=None,
                  link_padding=None, link_scale=None, object_colors=None, world=None,
                  is_diff=False):
-        self.name = name  # string
-        self.robot_state = robot_state or RobotState()  # moveit_msgs/RobotState
-        self.robot_model_name = robot_model_name  # string
+        self.name = name                                            # string
+        self.robot_state = robot_state or RobotState()              # moveit_msgs/RobotState
+        self.robot_model_name = robot_model_name                    # string
         self.fixed_frame_transforms = fixed_frame_transforms or []  # geometry_msgs/TransformStamped[]
         self.allowed_collision_matrix = allowed_collision_matrix or AllowedCollisionMatrix()
-        self.link_padding = link_padding or []  # moveit_msgs/LinkPadding[]
-        self.link_scale = link_scale or []  # moveit_msgs/LinkScale[]
-        self.object_colors = object_colors or []  # moveit_msgs/ObjectColor[]
-        self.world = world or PlanningSceneWorld()  # moveit_msgs/PlanningSceneWorld
-        self.is_diff = is_diff  # bool
-
-        """
-        SCENE_SETTINGS = 1
-        ROBOT_STATE=2
-        ROBOT_STATE_ATTACHED_OBJECTS=4
-        WORLD_OBJECT_NAMES=8
-        WORLD_OBJECT_GEOMETRY=16
-        OCTOMAP=32
-        TRANSFORMS=64
-        ALLOWED_COLLISION_MATRIX=128
-        LINK_PADDING_AND_SCALING=256
-        OBJECT_COLORS=512
-        """
+        self.link_padding = link_padding or []                      # moveit_msgs/LinkPadding[]
+        self.link_scale = link_scale or []                          # moveit_msgs/LinkScale[]
+        self.object_colors = object_colors or []                    # moveit_msgs/ObjectColor[]
+        self.world = world or PlanningSceneWorld()                  # moveit_msgs/PlanningSceneWorld
+        self.is_diff = is_diff                                      # bool
 
     @classmethod
     def from_msg(cls, msg):
@@ -515,3 +508,36 @@ class PlanningScene(ROSmsg):
                    msg['fixed_frame_transforms'], allowed_collision_matrix,
                    msg['link_padding'], msg['link_scale'], msg['object_colors'],
                    world, msg['is_diff'])
+
+
+class ExecuteTrajectoryGoal(ROSmsg):
+    """http://docs.ros.org/kinetic/api/moveit_msgs/html/action/ExecuteTrajectory.html
+    """
+
+    def __init__(self, trajectory=None):
+        self.trajectory = trajectory or RobotTrajectory()
+
+
+class ExecuteTrajectoryFeedback(ROSmsg):
+    """http://docs.ros.org/kinetic/api/moveit_msgs/html/action/ExecuteTrajectory.html
+    """
+
+    def __init__(self, state=None):
+        self.state = state
+
+    @classmethod
+    def from_msg(cls, msg):
+        return cls(msg['state'])
+
+
+class ExecuteTrajectoryResult(ROSmsg):
+    """http://docs.ros.org/kinetic/api/moveit_msgs/html/action/ExecuteTrajectory.html
+    """
+
+    def __init__(self, error_code=None):
+        self.error_code = error_code or MoveItErrorCodes()  # moveit_msgs/MoveItErrorCodes
+
+    @classmethod
+    def from_msg(cls, msg):
+        error_code = MoveItErrorCodes.from_msg(msg['error_code'])
+        return cls(error_code)

--- a/src/compas_fab/backends/ros/messages/trajectory_msgs.py
+++ b/src/compas_fab/backends/ros/messages/trajectory_msgs.py
@@ -4,20 +4,17 @@ from .std_msgs import ROSmsg
 from .std_msgs import Header
 from .std_msgs import Time
 
-from .geometry_msgs import Transform
-from .geometry_msgs import Twist
-
 
 class JointTrajectoryPoint(ROSmsg):
     """http://docs.ros.org/kinetic/api/trajectory_msgs/html/msg/JointTrajectoryPoint.html
     """
 
     def __init__(self, positions=None, velocities=None, accelerations=None, effort=None, time_from_start=None):
-        self.positions = positions if positions else []
-        self.velocities = velocities if velocities else []
-        self.accelerations = accelerations if accelerations else []
-        self.effort = effort if effort else []
-        self.time_from_start = time_from_start if time_from_start else Time()
+        self.positions = positions or []
+        self.velocities = velocities or []
+        self.accelerations = accelerations or []
+        self.effort = effort or []
+        self.time_from_start = time_from_start or Time()
         # TODO: check if we need to enter zeros to all
 
     @classmethod
@@ -40,9 +37,9 @@ class JointTrajectory(ROSmsg):
     """
 
     def __init__(self, header=None, joint_names=None, points=None):
-        self.header = header if header else Header()
-        self.joint_names = joint_names if joint_names else []
-        self.points = points if points else []
+        self.header = header or Header()
+        self.joint_names = joint_names or []
+        self.points = points or []
 
     @classmethod
     def from_msg(cls, msg):
@@ -57,10 +54,10 @@ class MultiDOFJointTrajectoryPoint(ROSmsg):
     """
 
     def __init__(self, transforms=None, velocities=None, accelerations=None, time_from_start=None):
-        self.transforms = transforms if transforms else []  # geometry_msgs/Transform[]
-        self.velocities = velocities if velocities else []  # geometry_msgs/Twist[]
-        self.accelerations = accelerations if accelerations else []  # geometry_msgs/Twist[]
-        self.time_from_start = time_from_start if time_from_start else Time()
+        self.transforms = transforms or []        # geometry_msgs/Transform[]
+        self.velocities = velocities or []        # geometry_msgs/Twist[]
+        self.accelerations = accelerations or []  # geometry_msgs/Twist[]
+        self.time_from_start = time_from_start or Time()
 
 
 class MultiDOFJointTrajectory(ROSmsg):
@@ -68,9 +65,9 @@ class MultiDOFJointTrajectory(ROSmsg):
     """
 
     def __init__(self, header=None, joint_names=None, points=None):
-        self.header = header if header else Header()
-        self.joint_names = joint_names if joint_names else []
-        self.points = points if points else []
+        self.header = header or Header()
+        self.joint_names = joint_names or []
+        self.points = points or []
 
     @classmethod
     def from_msg(cls, msg):

--- a/src/compas_fab/backends/ros/planner_backend_moveit.py
+++ b/src/compas_fab/backends/ros/planner_backend_moveit.py
@@ -93,13 +93,18 @@ class MoveItPlanner(PlannerBackend):
                                             GetPlanningSceneResponse)
 
     def init_planner(self):
-        self.collision_object_topic = Topic(self, '/collision_object',
-                                            'moveit_msgs/CollisionObject', queue_size=None)
+        self.collision_object_topic = Topic(
+            self,
+            '/collision_object',
+            'moveit_msgs/CollisionObject',
+            queue_size=None)
         self.collision_object_topic.advertise()
 
         self.attached_collision_object_topic = Topic(
-            self, '/attached_collision_object',
-            'moveit_msgs/AttachedCollisionObject', queue_size=None)
+            self,
+            '/attached_collision_object',
+            'moveit_msgs/AttachedCollisionObject',
+            queue_size=None)
         self.attached_collision_object_topic.advertise()
 
     def dispose_planner(self):
@@ -133,7 +138,10 @@ class MoveItPlanner(PlannerBackend):
                                        avoid_collisions=avoid_collisions,
                                        attempts=attempts)
 
-        self.GET_POSITION_IK(self, (ik_request, ), callback, errback)
+        def convert_to_positions(response):
+            callback(response.solution.joint_state.position)
+
+        self.GET_POSITION_IK(self, (ik_request, ), convert_to_positions, errback)
 
     def forward_kinematics_async(self, callback, errback, joint_positions, base_link,
                                  group, joint_names, ee_link):
@@ -145,8 +153,11 @@ class MoveItPlanner(PlannerBackend):
         robot_state = RobotState(
             joint_state, MultiDOFJointState(header=header))
 
+        def convert_to_frame(response):
+            callback(response.pose_stamped[0].pose.frame)
+
         self.GET_POSITION_FK(self, (header, fk_link_names,
-                                    robot_state), callback, errback)
+                                    robot_state), convert_to_frame, errback)
 
     def plan_cartesian_motion_async(self, callback, errback, frames, base_link,
                                     ee_link, group, joint_names, joint_types,

--- a/src/compas_fab/backends/ros/planner_backend_moveit.py
+++ b/src/compas_fab/backends/ros/planner_backend_moveit.py
@@ -151,7 +151,7 @@ class MoveItPlanner(PlannerBackend):
     def plan_cartesian_motion_async(self, callback, errback, frames, base_link,
                                     ee_link, group, joint_names, joint_types,
                                     start_configuration, max_step, jump_threshold,
-                                    avoid_collisions, path_constraints, 
+                                    avoid_collisions, path_constraints,
                                     attached_collision_meshes):
         """Asynchronous handler of MoveIt cartesian motion planner service."""
         header = Header(frame_id=base_link)
@@ -179,6 +179,7 @@ class MoveItPlanner(PlannerBackend):
             trajectory = JointTrajectory()
             trajectory.source_message = response
             trajectory.fraction = response.fraction
+            trajectory.joint_names = response.solution.joint_trajectory.joint_names
             trajectory.points = convert_trajectory_points(response.solution.joint_trajectory.points, joint_types)
             trajectory.start_configuration = Configuration(response.start_state.joint_state.position, start_configuration.types)
 
@@ -260,6 +261,7 @@ class MoveItPlanner(PlannerBackend):
             trajectory = JointTrajectory()
             trajectory.source_message = response
             trajectory.fraction = 1.
+            trajectory.joint_names = response.trajectory.joint_trajectory.joint_names
             trajectory.points = convert_trajectory_points(response.trajectory.joint_trajectory.points, joint_types)
             trajectory.start_configuration = Configuration(response.trajectory_start.joint_state.position, start_configuration.types)
             trajectory.planning_time = response.planning_time

--- a/src/compas_fab/backends/tasks.py
+++ b/src/compas_fab/backends/tasks.py
@@ -2,19 +2,74 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import threading
+
 __all__ = [
-    'CancellableTask',
+    'FutureResult',
+    'CancellableFutureResult'
 ]
 
 
-class CancellableTask(object):
-    """Preemptable task represents a long-running operation that can be cancelled."""
+class FutureResult(object):
+    """Represents a future result value.
+
+    Futures are the result of asynchronous operations
+    but allow to explicitely control when to block and wait
+    for its completion."""
+
+    def __init__(self):
+        self.done = False
+        self.value = None
+        self.error = None
+        self.event = threading.Event()
+
+    def result(self, timeout=None):
+        """Return the feedback value returned by the instruction.
+
+        If the instruction has not yet returned feedback, it will wait
+        up to ``timeout`` seconds. If the ``timeout`` expires, the method
+        will raise an exception.
+        """
+        if not self.done:
+            if not self.event.wait(timeout):
+                raise Exception('Timeout: future result not available')
+
+        if self.error:
+            raise self.error
+
+        return self.value
+
+    def _set_result(self, message):
+        self.done = True
+        self.value = message
+        self.error = None
+        self.event.set()
+
+    def _set_error_result(self, error):
+        """Mark the future as failed.
+
+        Parameters
+        ----------
+        error : Exception
+            An exception instance.
+        """
+        self.done = True
+        self.value = None
+        self.error = error
+        self.event.set()
+
+
+class CancellableFutureResult(FutureResult):
+    """Represents a future result of a long-running asynchronous operation that can be cancelled."""
+
+    def __init__(self):
+        super(CancellableFutureResult, self).__init__()
 
     def cancel(self):
-        """Attempt to cancel the task.
+        """Attempt to cancel the operation.
 
-        If the task is currently being executed and cannot be cancelled
+        If the operation is currently being executed and cannot be cancelled
         then the method will return ``False``, otherwise the call will
         be cancelled and the method will return ``True``.
         """
-        raise NotImplementedError('Concrete tasks need to provide an implementation')
+        raise NotImplementedError('Needs concrete implementation')

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1176,21 +1176,6 @@ class Robot(object):
 
         return trajectory
 
-    def send_frame(self):
-        # (check service name with ros)
-        self.ensure_client()
-        raise NotImplementedError
-
-    def send_configuration(self):
-        # (check service name with ros)
-        self.ensure_client()
-        raise NotImplementedError
-
-    def send_trajectory(self):
-        # (check service name with ros)
-        self.ensure_client()
-        raise NotImplementedError
-
     def transformed_frames(self, configuration, group=None):
         """Returns the robot's transformed frames."""
         joint_names = self.get_configurable_joint_names(group)

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -833,12 +833,10 @@ class Robot(object):
         frame_RCF = self.represent_frame_in_RCF(frame_WCF, group)
         frame_RCF.point /= self.scale_factor  # must be in meters
 
-        response = self.client.inverse_kinematics(frame_RCF, base_link,
+        joint_positions = self.client.inverse_kinematics(frame_RCF, base_link,
                                                   group, joint_names, joint_positions,
                                                   avoid_collisions, constraints, attempts,
                                                   attached_collision_meshes)
-
-        joint_positions = response.solution.joint_state.position
         joint_positions = self._scale_joint_values(joint_positions, self.scale_factor)
         # full configuration # TODO group config?
         configuration = Configuration(joint_positions, self.get_configurable_joint_types())
@@ -900,8 +898,7 @@ class Robot(object):
 
         if not backend:
             if self.client:
-                response = self.client.forward_kinematics(full_joint_positions, base_link_name, group, full_joint_names, link_name)
-                frame_RCF = response.pose_stamped[0].pose.frame
+                frame_RCF = self.client.forward_kinematics(full_joint_positions, base_link_name, group, full_joint_names, link_name)
                 frame_RCF.point *= self.scale_factor
             else:
                 frame_WCF = self.model.forward_kinematics(group_joint_state, link_name)

--- a/src/compas_fab/robots/trajectory.py
+++ b/src/compas_fab/robots/trajectory.py
@@ -140,8 +140,10 @@ class JointTrajectory(Trajectory):
 
     Attributes
     ----------
-    points: :obj:`list` of :class:`JointTrajectoryPoint`
+    trajectory_points: :obj:`list` of :class:`JointTrajectoryPoint`
         List of points composing the trajectory.
+    joint_names: :obj:`list` of :obj:`str`
+        List of joint names of the trajectory.
     start_configuration: :class:`Configuration`
         Start configuration for the trajectory.
     fraction: float
@@ -149,9 +151,10 @@ class JointTrajectory(Trajectory):
         e.g. ``1`` means the full trajectory was found.
     """
 
-    def __init__(self, trajectory_points=[], start_configuration=None, fraction=None):
+    def __init__(self, trajectory_points=[], joint_names=[], start_configuration=None, fraction=None):
         super(Trajectory, self).__init__()
         self.points = trajectory_points
+        self.joint_names = joint_names
         self.start_configuration = start_configuration
         self.fraction = fraction
 
@@ -181,15 +184,18 @@ class JointTrajectory(Trajectory):
     @property
     def data(self):
         """:obj:`dict` : The data representing the trajectory."""
-        return {
-            'points': [p.to_data() for p in self.points],
-            'start_configuration': self.start_configuration.to_data(),
-            'fraction': self.fraction,
-        }
+        data_obj = {}
+        data_obj['points'] = [p.to_data() for p in self.points]
+        data_obj['joint_names'] = self.joint_names or []
+        data_obj['start_configuration'] = self.start_configuration.to_data()
+        data_obj['fraction'] = self.fraction
+
+        return data_obj
 
     @data.setter
     def data(self, data):
         self.points = list(map(JointTrajectoryPoint.from_data, data.get('points') or []))
+        self.joint_names = data.get('joint_names', [])
         self.start_configuration = Configuration.from_data(data.get('start_configuration'))
         self.fraction = data.get('fraction')
 


### PR DESCRIPTION
Changed the ROS client trajectory follower to handle (in a backwards-compatible way) arguments of generic trajectory type.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas_fab.robots.Configuration`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
