### PR TITLE
Assume a robot without a parent joint on its base is on the worldXY origin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Unreleased
 
 **Fixed**
 
+* Use WorldXY's origin as default for robots that are have no parent join on their base
+
 **Deprecated**
 
 0.7.0

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -270,7 +270,7 @@ class Robot(object):
         --------
         """
 
-        base_link = self.get_base_link_name(group)
+        base_link = self.get_base_link(group)
         # the group's original base_frame
         base_frame = self.get_base_frame(group)
 
@@ -282,7 +282,11 @@ class Robot(object):
         # That's why we have to do the workaround with the Transformation.
 
         joint_state = dict(zip(joint_names, joint_positions))
-        base_frame_WCF = self.model.forward_kinematics(joint_state, link_name=base_link)
+
+        if not base_link.parent_joint:
+            base_frame_WCF = Frame.worldXY()
+        else:
+            base_frame_WCF = self.model.forward_kinematics(joint_state, link_name=base_link.name)
         base_frame_RCF = self.represent_frame_in_RCF(base_frame_WCF, group)
 
         base_frame_RCF.point *= self.scale_factor


### PR DESCRIPTION
Rather simplistic fix for robots that are not attached to any fixed joint, like world or similar.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas_fab.robots.Configuration`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
