### PR TITLE
Bump dependency to compas 0.10.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Unreleased
 
 **Changed**
 
+* Updated to COMPAS 0.10
+
 **Removed**
 
 **Fixed**

--- a/docs/examples/01_fundamentals/01_frame_and_transformation.rst
+++ b/docs/examples/01_fundamentals/01_frame_and_transformation.rst
@@ -33,7 +33,7 @@ coordinate system.
     # point in F (local coordinates)
     P = Point(35., 35., 35.)
     # point in global (world) coordinates
-    P_ = F.represent_point_in_global_coordinates(P)
+    P_ = F.to_world_coords(P)
 
 
 Industrial robots do not have a common way of describing the pose orientation.

--- a/docs/examples/01_fundamentals/02_coordinate_frames.rst
+++ b/docs/examples/01_fundamentals/02_coordinate_frames.rst
@@ -112,10 +112,10 @@ before sending it as a target pose to the robot.
     frame_WCF = Frame(point, xaxis, yaxis)
     print("frame in WCF", frame_WCF)
 
-    frame_RCF = robot.represent_frame_in_RCF(frame_WCF)
+    frame_RCF = robot.to_local_coords(frame_WCF)
     print("frame in RCF", frame_RCF)
 
-    frame_WCF = robot.represent_frame_in_WCF(frame_RCF)
+    frame_WCF = robot.to_world_coords(frame_RCF)
     print("frame in WCF", frame_WCF)
 
 Links

--- a/docs/examples/03_backends_ros/files/02_forward_kinematics.py
+++ b/docs/examples/03_backends_ros/files/02_forward_kinematics.py
@@ -5,7 +5,7 @@ robot = Robot()
 configuration = Configuration.from_revolute_values([-2.238, -1.153, -2.174, 0.185, 0.667, 0.])
 
 frame_RCF = robot.forward_kinematics(configuration)
-frame_WCF = robot.represent_frame_in_WCF(frame_RCF)
+frame_WCF = robot.to_world_coords(frame_RCF)
 
 print("Frame in the robot's coordinate system")
 print(frame_RCF)

--- a/docs/examples/03_backends_ros/files/02_forward_kinematics_ros.py
+++ b/docs/examples/03_backends_ros/files/02_forward_kinematics_ros.py
@@ -7,7 +7,7 @@ with RosClient() as client:
     configuration = Configuration.from_revolute_values([-2.238, -1.153, -2.174, 0.185, 0.667, 0.])
 
     frame_RCF = robot.forward_kinematics(configuration)
-    frame_WCF = robot.represent_frame_in_WCF(frame_RCF)
+    frame_WCF = robot.to_world_coords(frame_RCF)
 
     print("Frame in the robot's coordinate system")
     print(frame_RCF)

--- a/docs/examples/03_backends_ros/files/robot.ghx
+++ b/docs/examples/03_backends_ros/files/robot.ghx
@@ -1298,7 +1298,7 @@ if robot and configuration:
         frames = draw_pipes(pipes, cap=1)
 
     ee_frame_RCF = robot.forward_kinematics(configuration, backend='model')
-    ee_frame = robot.represent_frame_in_WCF(ee_frame_RCF)
+    ee_frame = robot.to_world_coords(ee_frame_RCF)
     ee_plane = draw_frame(ee_frame)
 
     print("End-effector frame:")
@@ -5236,7 +5236,7 @@ if robot:
 
 if sc.sticky[response_key]:
     frame_RCF = sc.sticky[response_key]
-    frame_WCF = robot.represent_frame_in_WCF(frame_RCF, group)
+    frame_WCF = robot.to_world_coords(frame_RCF, group)
 
 print frame_WCF</item>
                     <item name="Description" type_name="gh_string" type_code="10">GhPython provides a Python script component</item>

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 requirements = [
     # Until COMPAS reaches 1.0, we pin major.minor and allow patch version updates
-    'compas>=0.8.1,<0.9',
+    'compas>=0.10,<0.11',
     'roslibpy>=0.7',
     'pyserial',
 ]

--- a/src/compas_fab/robots/constraints.py
+++ b/src/compas_fab/robots/constraints.py
@@ -226,7 +226,14 @@ class OrientationConstraint(Constraint):
     def transform(self, transformation):
         R = Rotation.from_quaternion(self.quaternion)
         R = transformation * R
-        self.quaternion = R.rotation.quaternion
+
+        # Due to a bug on COMPAS 0.10.0
+        # (Fixed on https://github.com/compas-dev/compas/pull/378 but not released atm)
+        # we work around the retrival of the rotation component of R and instead decompose and get it
+        _, _, r, _, _ = R.decomposed()
+        self.quaternion = r.quaternion
+        # After that bug fix is released, the previous two lines should be changed to:
+        # self.quaternion = R.rotation.quaternion
 
     def __repr__(self):
         return "OrientationConstraint('{0}', {1}, {2}, {3})".format(self.link_name, self.quaternion, self.tolerances, self.weight)


### PR DESCRIPTION
This updates `compas_fab` dependency on `compas` to the latest release and changes the `Robot`'s `represent_*` methods to match the new naming.

This is a breaking change because the robot's methods have been renamed, without fallback to the previous names.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas_fab.robots.Configuration`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
