### PR TITLE
Add support for DAE files and multiple meshes per mesh descriptor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Unreleased
 
 * Use WorldXY's origin as default for robots that are have no parent join on their base
 * Fixed parsing of semantics (SRDF) containing nested groups
+* Fixed DAE support on ROS File loader
 
 **Deprecated**
 

--- a/docs/backends/files/panda-demo/docker-compose.yml
+++ b/docs/backends/files/panda-demo/docker-compose.yml
@@ -38,6 +38,29 @@ services:
       - file_server
       - file_server.launch
 
+  panda-tf-panda_link0:
+    image: gramaziokohler/ros-panda-planner:19.04
+    container_name: panda-tf-panda_link0
+    environment:
+      - ROS_HOSTNAME=panda-tf-panda_link0
+      - ROS_MASTER_URI=http://ros-master:11311
+    depends_on:
+      - ros-master
+    command:
+      - rosrun
+      - tf
+      - static_transform_publisher
+      - '0'
+      - '0'
+      - '0'
+      - '0'
+      - '0'
+      - '0'
+      - '1'
+      - world
+      - panda_link0
+      - '100'
+
   panda-demo:
     image: gramaziokohler/ros-panda-planner:19.04
     container_name: panda-demo

--- a/src/compas_fab/artists/base.py
+++ b/src/compas_fab/artists/base.py
@@ -89,14 +89,34 @@ class BaseRobotArtist(object):
             link = self.robot.root
 
         for item in itertools.chain(link.visual, link.collision):
-            if item.geometry.geo:
+            # NOTE: Currently, shapes assign their meshes to an
+            # attribute called `geometry`, but this will change soon to `meshes`.
+            # This code handles the situation in a forward-compatible
+            # manner. Eventually, this can be simplified to use only `meshes` attr
+            if hasattr(item.geometry.shape, 'meshes'):
+                meshes = item.geometry.shape.meshes
+            else:
+                meshes = item.geometry.shape.geometry
+
+            if meshes:
+                # Coerce meshes into an iteratable (a tuple if not natively iterable)
+                if not hasattr(meshes, '__iter__'):
+                    meshes = (meshes,)
+
                 color = None
                 if hasattr(item, 'get_color'):
                     color = item.get_color()
-                # create native geometry
-                item.native_geometry = self.draw_geometry(item.geometry.geo, color)
-                # transform native geometry based on saved init transform
-                self.transform(item.native_geometry, item.init_transformation)
+
+                native_geometry = []
+                for mesh in meshes:
+                    # create native geometry
+                    native_mesh = self.draw_geometry(mesh, color)
+                    # transform native geometry based on saved init transform
+                    self.transform(native_mesh, item.init_transformation)
+                    # append to list
+                    native_geometry.append(native_mesh)
+
+                item.native_geometry = native_geometry
                 item.current_transformation = Transformation()
 
         for child_joint in link.joints:
@@ -128,7 +148,8 @@ class BaseRobotArtist(object):
             # Some links have only collision geometry, not visual. These meshes
             # have not been loaded.
             if item.native_geometry:
-                self.transform(item.native_geometry, transformation)
+                for geometry in item.native_geometry:
+                    self.transform(geometry, transformation)
 
         for child_joint in link.joints:
             # Recursive call
@@ -152,7 +173,8 @@ class BaseRobotArtist(object):
         None
         """
         relative_transformation = transformation * item.current_transformation.inverse()
-        self.transform(item.native_geometry, relative_transformation)
+        for native_geometry in item.native_geometry:
+            self.transform(native_geometry, relative_transformation)
         item.current_transformation = transformation
 
     def update(self, configuration, names, visual=True, collision=True):
@@ -190,11 +212,14 @@ class BaseRobotArtist(object):
         """Draws all visual geometry of the robot."""
         for link in self.robot.iter_links():
             for item in link.visual:
-                yield item.native_geometry
+                if item.native_geometry:
+                    for native_geometry in item.native_geometry:
+                        yield native_geometry
 
     def draw_collision(self):
         """Draws all collision geometry of the robot."""
         for link in self.robot.iter_links():
             for item in link.collision:
                 if item.native_geometry:
-                    yield item.native_geometry
+                    for native_geometry in item.native_geometry:
+                        yield native_geometry

--- a/src/compas_fab/backends/ros/fileserver_loader.py
+++ b/src/compas_fab/backends/ros/fileserver_loader.py
@@ -240,7 +240,10 @@ def _dae_mesh_importer(filename):
             M = [float(i) for i in matrix_node.text.split()]
 
             # If it's the identity matrix, then ignore, we don't need to transform it
-            if M != [1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]:
+            if M != [1., 0., 0., 0.,
+                     0., 1., 0., 0.,
+                     0., 0., 1., 0.,
+                     0., 0., 0., 1.]:
                 M = M[0:4], M[4:8], M[8:12], M[12:16]
                 transform = Transformation.from_matrix(M)
 

--- a/src/compas_fab/backends/ros/fileserver_loader.py
+++ b/src/compas_fab/backends/ros/fileserver_loader.py
@@ -264,7 +264,7 @@ def _dae_mesh_importer(filename, precision):
         vertices = [[float(p) for p in positions[i:i + 3]] for i in range(0, len(positions), 3)]
 
         # Parse faces
-        faces = [int(f) for f in triangle_set_data[::2]]  # Ignore normals (ever second item is normal index)
+        faces = [int(f) for f in triangle_set_data[::2]]  # Ignore normals (every second item is normal index)
         faces = [faces[i:i + 3] for i in range(0, len(faces), 3)]
 
         # Rebuild vertices and faces using the same logic that other importers


### PR DESCRIPTION
This PR fixes several issues that are visible when parsing Panda model:
- [x] Add support for multiple meshes per mesh descriptor
- [x] Fix DAE parser (take into account precision and locally defined transforms)
- [x] Fix missing world to base linkage on panda docker example

This is the final result, the panda model is being read directly off of ROS via the file loader server:

![image](https://user-images.githubusercontent.com/933277/67943489-6bb55900-fbda-11e9-91e9-f54fe29d5b89.png)


### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.

### Checklist

1. [x] Add the change to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading: `Added`, `Changed`, `Removed`.
1. [x] Run all tests on your computer (i.e. `invoke test`).
1. [ ] If you add new functions/classes, check that:
   1. [ ] Are available on a second-level import, e.g. `compas_fab.robots.Configuration`.
   1. [ ] Add unit tests (especially important for algorithm implementations).
