### PR TITLE
Adding commit hash to version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,22 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+
+Unreleased
+----------
+
+**Added**
+
+* ..
+
+**Changed**
+
+**Removed**
+
+**Fixed**
+
+**Deprecated**
+
 0.9.0
 ----------
 

--- a/src/compas_fab/__init__.py
+++ b/src/compas_fab/__init__.py
@@ -35,6 +35,7 @@ from .__version__ import __url__
 from .__version__ import __version__
 
 HERE = os.path.dirname(__file__)
+HOME = os.path.abspath(os.path.join(HERE, '../..'))
 DATA = os.path.abspath(os.path.join(HERE, 'data'))
 
 
@@ -46,5 +47,26 @@ def _find_resource(filename):
 def get(filename):
     return _find_resource(filename)
 
+
+# Check if COMPAS is installed from git
+# If that's the case, try to append the current head's hash to __version__
+try:
+    git_head_file = os.path.abspath(os.path.join(HOME, '.git', 'HEAD'))
+
+    if os.path.exists(git_head_file):
+        # git head file contains one line that looks like this:
+        # ref: refs/heads/master
+        with open(git_head_file, 'r') as git_head:
+            _, ref_path = git_head.read().strip().split(' ')
+            ref_path = ref_path.split('/')
+
+            git_head_refs_file = os.path.abspath(os.path.join(HOME, '.git', *ref_path))
+
+        if os.path.exists(git_head_refs_file):
+            with open(git_head_refs_file, 'r') as git_head_ref:
+                git_commit = git_head_ref.read().strip()
+                __version__ += '-' + git_commit[:8]
+except Exception:
+    pass
 
 __all__ = ['__author__', '__author_email__', '__copyright__', '__description__', '__license__', '__title__', '__url__', '__version__', 'get']


### PR DESCRIPTION
Matching the behavior of `compas`, now `compas_fab` also includes the git commit hash in the `compas_fab.__version__` identifier if installed from source.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`) .
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
