### PR TITLE
Fix DAE parser to handle polylist-based  meshes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Unreleased
 
 **Fixed**
 
+* Fix DAE parser to handle ``polylist`` meshes
+
 **Deprecated**
 
 0.10.0


### PR DESCRIPTION
DAE supports multiple geometric primitives to define meshes, this PR adds support for one more (`polylist`), and raises an exception if the primitive is not yet supported.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`) .
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
