### PR TITLE
Suggestion to add option to run pytest-cov through invoke test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then
       python3 -m invoke lint || python -m invoke lint;
     fi
-  - python3 -m invoke test --no-doctest || python -m invoke test --no-doctest
+  - python3 -m invoke test || python -m invoke test
   - if [[ "$TRAVIS_GENERATE_DOCS" == "true" ]]; then
       python3 -m invoke docs || python -m invoke docs;
     fi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ flake8
 autopep8
 pylint
 pytest
+pytest-cov
 isort
 twine
 -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,5 +43,3 @@ skip = migrations
 
 [coverage:run]
 branch = True
-source =
-    ./src

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,3 +40,8 @@ default_section = THIRDPARTY
 forced_separate = test_compas_fab
 not_skip = __init__.py
 skip = migrations
+
+[coverage:run]
+branch = True
+source =
+    ./src

--- a/tasks.py
+++ b/tasks.py
@@ -199,14 +199,18 @@ def deploy_docs(ctx):
 
 @task(help={
       'doctest': 'True to run doctest modules, otherwise False.',
+      'coverage': 'True to generate coverage report using pytest-cov'
       })
-def test(ctx, doctest=True):
+def test(ctx, doctest=False, coverage=False):
     """Run all tests."""
-    if doctest:
-        ctx.run('pytest --doctest-modules')
-    else:
-        ctx.run('pytest')
 
+    pytest_args = ['pytest']
+    if doctest:
+        pytest_args.append('--doctest-modules')
+    if coverage:
+        pytest_args.append('--cov=./ --cov-report xml')
+
+    ctx.run(" ".join(pytest_args))
 
 @task(help={
       'release_type': 'Type of release follows semver rules. Must be one of: major, minor, patch.'})

--- a/tasks.py
+++ b/tasks.py
@@ -208,8 +208,7 @@ def test(ctx, doctest=False, coverage=False):
     if doctest:
         pytest_args.append('--doctest-modules')
     if coverage:
-        # cov-report is set to xml mostly for vscode plugin brainfit.vscode-coverage-highlighter
-        pytest_args.append('--cov=compas_fab --cov-report xml')
+        pytest_args.append('--cov=compas_fab')
 
     ctx.run(" ".join(pytest_args))
 

--- a/tasks.py
+++ b/tasks.py
@@ -208,7 +208,8 @@ def test(ctx, doctest=False, coverage=False):
     if doctest:
         pytest_args.append('--doctest-modules')
     if coverage:
-        pytest_args.append('--cov=./ --cov-report xml')
+        # cov-report is set to xml mostly for vscode plugin brainfit.vscode-coverage-highlighter
+        pytest_args.append('--cov=compas_fab --cov-report xml')
 
     ctx.run(" ".join(pytest_args))
 


### PR DESCRIPTION
I though coverage analysis would be helpful for assessing the state of our documentation. This adds a switch to `invoke test` to run the plugin [pytest-cov](https://github.com/pytest-dev/pytest-cov) when testing.

I also switched the default value for the keyword argument `doctest` to `False` to match the command argument help. The Travis build on Linux runs doctest using `pytest --doctest-modules` so I don't think the CI setup will be impacted by this change

```
$ inv test --help
Usage: inv[oke] [--core-opts] test [--options] [other tasks here ...]

Docstring:
  Run all tests.

Options:
  -c, --coverage   True to generate coverage report using pytest-cov
  -d, --doctest    True to run doctest modules, otherwise False.
```

### What type of change is this?
- [x] Other (e.g. doc update, configuration, etc)

### Checklist
- ~~[ ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).~~
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`) .
- ~~[ ] I have added tests that prove my fix is effective or that my feature works.~~
- [x] I have added necessary documentation (if appropriate)
