### PR TITLE
Convert constraints on IK and cartesian planner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Unreleased
 
 **Fixed**
 
+* Convert constraints on inverse kinematics and cartesian planner to ROS messages
+* Fix support for trajectory constraints on kinematic planner
+
 **Deprecated**
 
 0.10.2

--- a/src/compas_fab/backends/ros/planner_backend_moveit.py
+++ b/src/compas_fab/backends/ros/planner_backend_moveit.py
@@ -33,6 +33,7 @@ from compas_fab.backends.ros.messages import PoseStamped
 from compas_fab.backends.ros.messages import PositionConstraint
 from compas_fab.backends.ros.messages import PositionIKRequest
 from compas_fab.backends.ros.messages import RobotState
+from compas_fab.backends.ros.messages import TrajectoryConstraints
 from compas_fab.backends.ros.planner_backend import PlannerBackend
 from compas_fab.backends.ros.planner_backend import ServiceDescription
 from compas_fab.robots import Configuration
@@ -206,6 +207,8 @@ class MoveItPlanner(PlannerBackend):
                 aco = AttachedCollisionObject.from_attached_collision_mesh(acm)
                 start_state.attached_collision_objects.append(aco)
 
+        path_constraints = self._convert_constraints_to_rosmsg(path_constraints, header)
+
         request = dict(header=header,
                        start_state=start_state,
                        group_name=group,
@@ -264,38 +267,12 @@ class MoveItPlanner(PlannerBackend):
                 aco = AttachedCollisionObject.from_attached_collision_mesh(acm)
                 start_state.attached_collision_objects.append(aco)
 
-        # goal constraints
-        constraints = Constraints()
-        for c in goal_constraints:
-            if c.type == c.JOINT:
-                constraints.joint_constraints.append(
-                    JointConstraint.from_joint_constraint(c))
-            elif c.type == c.POSITION:
-                constraints.position_constraints.append(
-                    PositionConstraint.from_position_constraint(header, c))
-            elif c.type == c.ORIENTATION:
-                constraints.orientation_constraints.append(
-                    OrientationConstraint.from_orientation_constraint(header, c))
-            else:
-                raise NotImplementedError
-        goal_constraints = [constraints]
+        # convert constraints
+        goal_constraints = [self._convert_constraints_to_rosmsg(goal_constraints, header)]
+        path_constraints = self._convert_constraints_to_rosmsg(path_constraints, header)
 
-        # path constraints
-        if path_constraints:
-            constraints = Constraints()
-            for c in path_constraints:
-                if c.type == c.JOINT:
-                    constraints.joint_constraints.append(
-                        JointConstraint.from_joint_constraint(c))
-                elif c.type == c.POSITION:
-                    constraints.position_constraints.append(
-                        PositionConstraint.from_position_constraint(header, c))
-                elif c.type == c.ORIENTATION:
-                    constraints.orientation_constraints.append(
-                        OrientationConstraint.from_orientation_constraint(header, c))
-                else:
-                    raise NotImplementedError
-            path_constraints = constraints
+        if trajectory_constraints is not None:
+            trajectory_constraints = TrajectoryConstraints(constraints=self._convert_constraints_to_rosmsg(path_constraints, header))
 
         request = dict(start_state=start_state,
                        goal_constraints=goal_constraints,

--- a/src/compas_fab/backends/ros/planner_backend_moveit.py
+++ b/src/compas_fab/backends/ros/planner_backend_moveit.py
@@ -132,6 +132,22 @@ class MoveItPlanner(PlannerBackend):
             for acm in attached_collision_meshes:
                 aco = AttachedCollisionObject.from_attached_collision_mesh(acm)
                 start_state.attached_collision_objects.append(aco)
+        
+        # constraints
+        ik_constraints = Constraints()
+        for c in constraints:
+            if c.type == c.JOINT:
+                ik_constraints.joint_constraints.append(
+                    JointConstraint.from_joint_constraint(c))
+            elif c.type == c.POSITION:
+                ik_constraints.position_constraints.append(
+                    PositionConstraint.from_position_constraint(header, c))
+            elif c.type == c.ORIENTATION:
+                ik_constraints.orientation_constraints.append(
+                    OrientationConstraint.from_orientation_constraint(header, c))
+            else:
+                raise NotImplementedError
+        constraints = ik_constraints
 
         ik_request = PositionIKRequest(group_name=group,
                                        robot_state=start_state,


### PR DESCRIPTION
- Add `goal constraints` handling to `inverse_kinematics` of MoveIt planner.
- Add `trajectory_constraints` handling to `plan_cartesian_motion` of MoveIt planner.
- Refactor constraints conversion.

- [X] Bug fix in a **backwards-compatible** manner.