### PR TITLE
Merge pytest.ini with setup.cfg, remove doctest opt in setup.cfg

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-testpaths = tests src
-doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE ALLOW_BYTES

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ exclude =
 convention = numpy
 
 [tool:pytest]
-testpaths = tests
+testpaths = src tests
 norecursedirs =
     migrations
 
@@ -28,9 +28,9 @@ python_files =
 addopts =
     -ra
     --strict
-    --doctest-modules
     --doctest-glob=\*.rst
     --tb=short
+doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE ALLOW_BYTES
 
 [isort]
 force_single_line = True


### PR DESCRIPTION
Got confused when I couldn't find doctest_optionflags in setup.cfg, but then found them in pytest.ini. Is there a reason pytest is configured in two places? I might have misunderstood the setup though.

I also removed --doctest-modules from addopts since that's added to env on the linux travis job, and set by invoke test --doctest otherwise.

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Other (e.g. doc update, configuration, etc)

### Checklist

- ~~I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).~~
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`) .
- ~~I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.~~
- ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added necessary documentation (if appropriate)~~
