### PR TITLE
Solve Travis’ attrs version mismatch

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+attrs>=19.3.0
 sphinx_compas_theme>=0.4
 sphinx>=1.6
 invoke>=0.14

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import find_packages, setup
 requirements = [
     # Until COMPAS reaches 1.0, we pin major.minor and allow patch version updates
     'compas>=0.11,<0.14',
-    'roslibpy>=1.0.0',
+    'roslibpy>=0.7.1',
     'pyserial',
 ]
 keywords_list = ['robotic fabrication', 'digital fabrication', 'architecture', 'robotics', 'ros']

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import find_packages, setup
 requirements = [
     # Until COMPAS reaches 1.0, we pin major.minor and allow patch version updates
     'compas>=0.11,<0.14',
-    'roslibpy>=0.7.1',
+    'roslibpy>=1.0.0',
     'pyserial',
 ]
 keywords_list = ['robotic fabrication', 'digital fabrication', 'architecture', 'robotics', 'ros']


### PR DESCRIPTION
Builds fails because pytest specifies `attrs>=17.4.0` ([here](https://github.com/pytest-dev/pytest/blob/master/setup.py#L8)) while other compas_fab deps need 19.3.0 (e.g. six, twisted). By specifying `attrs` version in `requirements-dev.txt` we make sure we have the right version.

### What type of change is this?

- CI bug fix

### Checklist

- ~~I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).~~
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`) .


