### PR TITLE
Configurations search features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Unreleased
 * Added ``Configuration.scaled``
 * Added ``full_joint_state`` to ``Robot.inverse_kinematics``
 * Added ``Semantics.get_all_configurable_joints``
+* Added ``position_constraint_from_max_reach`` to constrain a specific link within a maximum distance of a point
+* Added ``iter_inverse_kinematics`` to search for a list of configurations, with given constraints
+* Added ``get_links_distance`` to calculate the distance between two robot's links
 
 **Changed**
 

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1177,9 +1177,9 @@ class Robot(object):
                                                         constraints=constraints,
                                                         attempts=attempts,
                                                         attached_collision_meshes=attached_collision_meshes,
-                                                        full_joint_state=full_joint_state)
+                                                        return_full_configuration=full_joint_state)
                 result_configurations.append(configuration)
-            except BaseException:
+            except:
                 # print("Error code: -31; NO_IK_SOLUTION")
                 pass
 

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1322,7 +1322,7 @@ class Robot(object):
 
         frames_WCF_scaled = []
         for frame in frames_WCF:
-            frames_WCF_scaled.append(Frame(frame.point * 1 / self.scale_factor, frame.xaxis, frame.yaxis))
+            frames_WCF_scaled.append(Frame(frame.point * 1. / self.scale_factor, frame.xaxis, frame.yaxis))
 
         if path_constraints:
             path_constraints_WCF_scaled = []

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -6,6 +6,7 @@ import logging
 import random
 
 from compas.geometry import Frame
+from compas.geometry import Scale
 from compas.geometry import Sphere
 from compas.geometry import Transformation
 from compas.robots import Joint
@@ -399,6 +400,9 @@ class Robot(object):
         """
         configurable_joints = self.get_configurable_joints(group)
         return [j.type for j in configurable_joints]
+    
+    def get_links_distance(self, link_name_1, link_name_2, group=None):
+        return None
 
     # ==========================================================================
     # configurations
@@ -830,6 +834,27 @@ class Robot(object):
         ee_link = self.get_end_effector_link_name(group)
         sphere = Sphere(frame_WCF.point, tolerance_position)
         return PositionConstraint.from_sphere(ee_link, sphere)
+    
+    def position_constraint_from_max_reach(self, target_point, link_name, max_reach, group=None):
+        """
+        Returns a position constraint for link_name with a sphere around the target point.
+        max_reach: the maximum span the arm can reach (radius of the reaching sphere).
+        """
+        if not group:
+            group = self.main_group_name
+
+        sphere = Sphere(target_point, max_reach)
+
+        if self.scale_factor != 1.0:
+            # NOTE: tried using BoundingVolume.scale(robot.scale_factor), but it only scales the target_point.
+            # NOTE: also the compas geometry transformation scale applies only to the center point of the sphere, not to the radius.
+            #       I find it misleading. Is that the intended result of scaling a Sphere?
+            _S = Scale([1.0 / self.scale_factor] * 3)
+            sphere.transform(_S)
+            sphere.radius = sphere.radius/self.scale_factor
+
+        bv = BoundingVolume.from_sphere(sphere)
+        return [PositionConstraint(link_name, bv, weight=1.)]
 
     def constraints_from_frame(self, frame_WCF, tolerance_position, tolerances_axes, group=None):
         """Returns a position and orientation constraint on the group's end-effector link.
@@ -1025,6 +1050,9 @@ class Robot(object):
             configuration = Configuration(values, self.get_configurable_joint_types(group), group_joint_names)
 
         return configuration.scaled(self.scale_factor)
+    
+    def iter_inverse_kinematics(self):
+        pass
 
     def forward_kinematics(self, configuration, group=None, backend=None, link_name=None):
         """Calculate the robot's forward kinematic.

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -403,8 +403,35 @@ class Robot(object):
         configurable_joints = self.get_configurable_joints(group)
         return [j.type for j in configurable_joints]
 
-    def get_links_distance(self, link_name_1, link_name_2, group=None):
-        return None
+    def get_links_distance(self, configuration, link_name_1, link_name_2, group=None):
+        """Calculate the distance between two robot's links.
+
+        Parameters
+        ----------
+        configuration : :class:`compas_fab.robots.Configuration`
+            The configuration of the robot to calculate the distance for.
+        link_name_1 : str
+            The name of the link to calculate the distance from.
+        link_name_2 : str
+            The name of the link to calculate the distance to.
+        group : str, optional
+            The planning group used for the calculation. Defaults to the robot's
+            main planning group.
+
+        Returns
+        -------
+        float
+            The distance between the links.
+        """
+        point_link_1 = robot.forward_kinematics(configuration,
+                                                group,
+                                                link_name=link_name_1).point
+        point_link_2 = robot.forward_kinematics(configuration,
+                                                group,
+                                                link_name=link_name_2).point
+
+        distance = point_link_1.distance_to_point(point_link_2)
+        return distance
 
     # ==========================================================================
     # configurations
@@ -853,7 +880,7 @@ class Robot(object):
             #       I find it misleading. Is that the intended result of scaling a Sphere?
             _S = Scale([1.0 / self.scale_factor] * 3)
             sphere.transform(_S)
-            sphere.radius = sphere.radius/self.scale_factor
+            sphere.radius = sphere.radius / self.scale_factor
 
         bv = BoundingVolume.from_sphere(sphere)
         return [PositionConstraint(link_name, bv, weight=1.)]
@@ -1295,7 +1322,7 @@ class Robot(object):
 
         frames_WCF_scaled = []
         for frame in frames_WCF:
-            frames_WCF_scaled.append(Frame(frame.point * 1. / self.scale_factor, frame.xaxis, frame.yaxis))
+            frames_WCF_scaled.append(Frame(frame.point * 1 / self.scale_factor, frame.xaxis, frame.yaxis))
 
         if path_constraints:
             path_constraints_WCF_scaled = []

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -423,12 +423,12 @@ class Robot(object):
         float
             The distance between the links.
         """
-        point_link_1 = robot.forward_kinematics(configuration,
-                                                group,
-                                                link_name=link_name_1).point
-        point_link_2 = robot.forward_kinematics(configuration,
-                                                group,
-                                                link_name=link_name_2).point
+        point_link_1 = self.forward_kinematics(configuration,
+                                               group,
+                                               link_name=link_name_1).point
+        point_link_2 = self.forward_kinematics(configuration,
+                                               group,
+                                               link_name=link_name_2).point
 
         distance = point_link_1.distance_to_point(point_link_2)
         return distance


### PR DESCRIPTION
Added some functionalities to :class:``compas_fab.robots.Robot``:
- ``position_constraint_from_max_reach`` to constrain a specific link within a maximum distance from a point
- ``iter_inverse_kinematics`` to search for a list of configurations, with given constraints (goal states search for planning goal constraints) 
- ``get_links_distance`` to calculate the distance between two robot's links

### What type of change is this?
- [X] New feature in a **backwards-compatible** manner.

### Checklist
- [X] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation (if appropriate)
