### PR TITLE
Revert workaround in compas.robots.OrientationConstraint.transform()

### DIFF
--- a/src/compas_fab/robots/constraints.py
+++ b/src/compas_fab/robots/constraints.py
@@ -237,13 +237,7 @@ class OrientationConstraint(Constraint):
         R = Rotation.from_quaternion(self.quaternion)
         R = transformation * R
 
-        # Due to a bug on COMPAS 0.10.0
-        # (Fixed on https://github.com/compas-dev/compas/pull/378 but not released atm)
-        # we work around the retrival of the rotation component of R and instead decompose and get it
-        _, _, r, _, _ = R.decomposed()
-        self.quaternion = r.quaternion
-        # After that bug fix is released, the previous two lines should be changed to:
-        # self.quaternion = R.rotation.quaternion
+        self.quaternion = R.rotation.quaternion
 
     def __repr__(self):
         return "OrientationConstraint('{0}', {1}, {2}, {3})".format(self.link_name, self.quaternion, self.tolerances, self.weight)


### PR DESCRIPTION
### What type of change is this?

Outdated workaround now that pinned version of compas has been bumped.

### Checklist

- ~~I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).~~
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`) .
- ~~I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.~~
-  ~~I have added tests that prove my fix is effective or that my feature works.~~
- ~~I have added necessary documentation (if appropriate).~~
