### PR TITLE
pydocstyle ignore D100 ”Missing docstring in public module”

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ exclude =
 
 [pydocstyle]
 convention = numpy
+add-ignore = D105
 
 [tool:pytest]
 testpaths = src tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ exclude =
 
 [pydocstyle]
 convention = numpy
-add-ignore = D105
+add-ignore = D100
 
 [tool:pytest]
 testpaths = src tests


### PR DESCRIPTION
I'd like to ignore error D105, "Missing docstring in magic method" (i.e. `__repr__`, `__eq__` etc). There is not much to say about these functions, they are what they are. If this is rejected I'd suggest we define some standard docstrings for these methods.