### PR TITLE
Fixes for class docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import os
 import sphinx_compas_theme
 
+from sphinx.ext.napoleon.docstring import NumpyDocstring
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
@@ -46,7 +48,6 @@ intersphinx_mapping = {'python': ('https://docs.python.org/', None),
 # autodoc options
 autodoc_default_options = {
     'member-order': 'bysource',
-    'special-members': '__init__',
     'exclude-members': '__weakref__',
     'undoc-members': True,
     'private-members': True,
@@ -93,3 +94,38 @@ napoleon_use_ivar = False
 napoleon_use_param = False
 napoleon_use_rtype = False
 
+# Parse Attributes and Class Attributes on Class docs same as parameters.
+# first, we define new methods for any new sections and add them to the class
+
+
+def parse_keys_section(self, section):
+    return self._format_fields('Keys', self._consume_fields())
+
+
+NumpyDocstring._parse_keys_section = parse_keys_section
+
+
+def parse_attributes_section(self, section):
+    return self._format_fields('Attributes', self._consume_fields())
+
+
+NumpyDocstring._parse_attributes_section = parse_attributes_section
+
+
+def parse_class_attributes_section(self, section):
+    return self._format_fields('Class Attributes', self._consume_fields())
+
+
+NumpyDocstring._parse_class_attributes_section = parse_class_attributes_section
+
+
+# we now patch the parse method to guarantee that the the above methods are
+# assigned to the _section dict
+def patched_parse(self):
+    self._sections['keys'] = self._parse_keys_section
+    self._sections['class attributes'] = self._parse_class_attributes_section
+    self._unpatched_parse()
+
+
+NumpyDocstring._unpatched_parse = NumpyDocstring._parse
+NumpyDocstring._parse = patched_parse


### PR DESCRIPTION
# Attribute section rendering

While working through docs I noticed that the lists of Attributes in the generated Sphinx documentation looked different compared to class documentation for Compas.

The difference comes from some patching of napoeleon (Sphinx extension) in `docs/conf.py` that @brgcode did. I copied this to compas_fab's `docs/conf.py`.

## Before

![before](https://user-images.githubusercontent.com/14882117/79364370-90fc1080-7f49-11ea-8a89-7a8c0f01a06d.png)

## After

![after](https://user-images.githubusercontent.com/14882117/79364396-98bbb500-7f49-11ea-9488-7f18adedd371.png)

# `__init__()` in class documentation

I also removed the option `'special-members': '__init__'` from  `autodoc_default_options`. The signature is already displayed at the top of the document. Having this option turned on results in the small init section at the bottom, and warnings like this while building the docs:
```
/[...]/compas_fab/src/compas_fab/robots/constraints.py:docstring of
compas_fab.robots.OrientationConstraint.__init__:1:
WARNING: duplicate object description of compas_fab.robots.OrientationConstraint.__init__,
other instance in reference/generated/compas_fab.robots.OrientationConstraint,
use :noindex: for one of them
```
## Removed `__init__()` section
![init](https://user-images.githubusercontent.com/14882117/79364797-1ed7fb80-7f4a-11ea-8c7f-06afd51f89fc.png)
