### PR TITLE
deepsource: test_patterns needs to be relative to proj root

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,6 @@
 version = 1
 
-test_patterns = ["*/tests/**"]
+test_patterns = ["tests/**"]
 
 [[analyzers]]
 name = "python"


### PR DESCRIPTION
Would remove all these false positives: https://deepsource.io/gh/compas-dev/compas_fab/issue/BAN-B101/occurrences
