### PR TITLE
Use new extension point for declaring rhino installable packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Unreleased
 * **PyBullet integration**: added support for PyBullet client and forward/inverse kinematic solver
 * Added ``ClientInterface``, ``PlannerInterface`` and various backend feature interfaces
 * Added implementations of these interfaces for ROS and V-REP
-* Added ``attributes`` dictionary to ``Robot`` class 
+* Added ``attributes`` dictionary to ``Robot`` class
 
 **Changed**
 
@@ -27,6 +27,7 @@ Unreleased
 * Parameter ``backend`` of forward kinematics has been renamed to ``solver``
 * The signatures of all kinematics, motion planning and planning scene management methods have been homogenized across backend clients and within ``Robot``
 * All examples have been updated to reflect these changes
+* The installer to Rhino has been unified with COMPAS core. Now running ``python -m compas_rhino.install`` will also detect and install COMPAS FAB and its dependencies.
 
 
 **Fixed**

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -40,12 +40,11 @@ Working in Rhino
 ================
 
 To make **COMPAS FAB** available inside Rhino, open the *command prompt*
-and type the following which will install it on both Rhino 5.0 and 6.0:
+and type the following:
 
 ::
 
-    python -m compas_fab.rhino.install -v 5.0
-    python -m compas_fab.rhino.install -v 6.0
+    python -m compas_rhino.install
 
 .. note:
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 requirements = [
     # Until COMPAS reaches 1.0, we pin major.minor and allow patch version updates
-    'compas>=0.16.4,<0.17',
+    'compas>=0.16.8,<0.17',
     'roslibpy>=1.1.0',
     'pybullet',
     'pyserial',

--- a/src/compas_fab/__init__.py
+++ b/src/compas_fab/__init__.py
@@ -69,4 +69,5 @@ try:
 except Exception:
     pass
 
+__all_plugins__ = ['compas_fab.rhino.install']
 __all__ = ['__author__', '__author_email__', '__copyright__', '__description__', '__license__', '__title__', '__url__', '__version__', 'get']

--- a/src/compas_fab/rhino/install.py
+++ b/src/compas_fab/rhino/install.py
@@ -2,26 +2,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import compas_rhino.install
-
-__all__ = []
-
-INSTALLABLE_PACKAGES = ['compas_fab', 'roslibpy']
+import compas.plugins
 
 
-# ==============================================================================
-# Main
-# ==============================================================================
+@compas.plugins.plugin(category='install')
+def installable_rhino_packages():
+    return ['compas_fab', 'roslibpy']
+
 
 if __name__ == "__main__":
-
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-v', '--version', choices=['5.0', '6.0'], default='6.0', help="The version of Rhino to install the packages in.")
-
-    args = parser.parse_args()
-
-    packages = set(compas_rhino.install.INSTALLABLE_PACKAGES + INSTALLABLE_PACKAGES)
-
-    compas_rhino.install.install(version=args.version, packages=packages)
+    print('This installation method is obsolete.')
+    print('Please use `python -m compas_rhino.install` instead')
+    print('COMPAS FAB will be automatically detected and installed')

--- a/src/compas_fab/rhino/uninstall.py
+++ b/src/compas_fab/rhino/uninstall.py
@@ -2,28 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import compas_rhino
-import compas_rhino.uninstall
-
-import compas_fab.rhino.install
-
-__all__ = []
-
-
-# ==============================================================================
-# Main
-# ==============================================================================
-
 if __name__ == "__main__":
-
-    import argparse
-
-    parser = argparse.ArgumentParser()
-
-    parser.add_argument('-v', '--version', choices=['5.0', '6.0'], default='5.0', help="The version of Rhino to install the packages in.")
-
-    args = parser.parse_args()
-
-    packages = set(compas_rhino.install.INSTALLABLE_PACKAGES + compas_fab.rhino.install.INSTALLABLE_PACKAGES)
-
-    compas_rhino.uninstall.uninstall(version=args.version, packages=packages)
+    print('This uninstallation method is obsolete.')
+    print('Please use `python -m compas_rhino.uninstall` instead')


### PR DESCRIPTION
This PR uses the changes on https://github.com/compas-dev/compas/pull/614 to remove the install/uninstall scripts and instead use the new extension points.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
