### PR TITLE
close #165: rename RobotArtist to RobotModelArtist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Unreleased
 * **PyBullet integration**: added support for PyBullet client and forward/inverse kinematic solver
 * Added ``ClientInterface``, ``PlannerInterface`` and various backend feature interfaces
 * Added implementations of these interfaces for ROS and V-REP
-* Added ``attributes`` dictionary to ``Robot`` class 
+* Added ``attributes`` dictionary to ``Robot`` class
 
 **Changed**
 
@@ -27,7 +27,8 @@ Unreleased
 * Parameter ``backend`` of forward kinematics has been renamed to ``solver``
 * The signatures of all kinematics, motion planning and planning scene management methods have been homogenized across backend clients and within ``Robot``
 * All examples have been updated to reflect these changes
-
+* Renamed all ``RobotArtist`` implementations to ``RobotModelArtist`` to reflect
+  the fact they depend on ``compas.robots.RobotModel``.
 
 **Fixed**
 
@@ -38,6 +39,7 @@ Unreleased
 * The methods ``forward_kinematics``, ``inverse_kinematics``, ``plan_cartesian_motion`` and ``plan_motion``
   of ``Robot`` class have been refactored, but a backwards-compatible deprecated version with the old
   signatures still exists suffixed by ``_deprecated``, e.g. ``forward_kinematics_deprecated``.
+* ``RobotArtist`` are deprecated in favor of ``RobotModelArtist``.
 
 **Removed**
 

--- a/docs/examples/02_description_models/02_robot.rst
+++ b/docs/examples/02_description_models/02_robot.rst
@@ -64,7 +64,7 @@ separated from the specific CAD interfaces, while providing a way to leverage
 native performance of the CAD environment.
 
 In the main library there are artists for various datastructures (meshes,
-networks, etc), and **COMPAS FAB** adds a ``RobotArtist`` to them.
+networks, etc), and **COMPAS FAB** adds a ``RobotModelArtist`` to them.
 Robot artists allow visualizing robot models easily and efficiently.
 
 The following example illustrates how to load an entire robot model from

--- a/docs/examples/02_description_models/files/02_robot_artist_blender.py
+++ b/docs/examples/02_description_models/files/02_robot_artist_blender.py
@@ -2,7 +2,7 @@ import compas
 compas.PRECISION = '12f'
 
 from compas.robots import *
-from compas_fab.blender import RobotArtist
+from compas_fab.blender import RobotModelArtist
 
 r = 'ros-industrial/abb'
 p = 'abb_irb6600_support'
@@ -11,7 +11,7 @@ b = 'kinetic-devel'
 github = GithubPackageMeshLoader(r, p, b)
 urdf = github.load_urdf('irb6640.urdf')
 
-robot = RobotModel.from_urdf_file(urdf)
-robot.load_geometry(github)
+model = RobotModel.from_urdf_file(urdf)
+model.load_geometry(github)
 
-RobotArtist(robot).draw_visual()
+RobotModelArtist(model).draw_visual()

--- a/docs/examples/02_description_models/files/02_robot_artist_grasshopper.ghx
+++ b/docs/examples/02_description_models/files/02_robot_artist_grasshopper.ghx
@@ -48,10 +48,10 @@
             <chunk name="Projection">
               <items count="2">
                 <item name="Target" type_name="gh_drawing_point" type_code="30">
-                  <X>-1</X>
-                  <Y>138</Y>
+                  <X>-480</X>
+                  <Y>205</Y>
                 </item>
-                <item name="Zoom" type_name="gh_single" type_code="5">1.06250012</item>
+                <item name="Zoom" type_name="gh_single" type_code="5">2</item>
               </items>
             </chunk>
             <chunk name="Views">
@@ -73,8 +73,8 @@
           <chunks count="1">
             <chunk name="Library" index="0">
               <items count="6">
-                <item name="AssemblyFullName" type_name="gh_string" type_code="10">Bengesht, Version=3.2.0.0, Culture=neutral, PublicKeyToken=null</item>
-                <item name="AssemblyVersion" type_name="gh_string" type_code="10">3.2.0.0</item>
+                <item name="AssemblyFullName" type_name="gh_string" type_code="10">Bengesht, Version=3.3.0.0, Culture=neutral, PublicKeyToken=null</item>
+                <item name="AssemblyVersion" type_name="gh_string" type_code="10">3.3.0.0</item>
                 <item name="Author" type_name="gh_string" type_code="10"></item>
                 <item name="Id" type_name="gh_guid" type_code="9">00000000-0000-0000-0000-000000000000</item>
                 <item name="Name" type_name="gh_string" type_code="10"></item>
@@ -137,7 +137,7 @@ import compas
 
 from compas.robots import RobotModel
 from compas.robots import GithubPackageMeshLoader
-from compas_fab.ghpython import RobotArtist
+from compas_fab.ghpython import RobotModelArtist
 
 # Robot meshes are usually in meters
 # Set a high percision to prevent parsing errors
@@ -160,7 +160,7 @@ if load:
 
     robot = RobotModel.from_urdf_file(github.load_urdf('irb6640.urdf'))
     robot.load_geometry(github)
-    robot.artist = RobotArtist(robot)
+    robot.artist = RobotModelArtist(robot)
 
     st[robot_key] = robot
 
@@ -525,7 +525,7 @@ if robot:
                   </items>
                   <chunks count="2">
                     <chunk name="Attributes">
-                      <items count="3">
+                      <items count="2">
                         <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                           <X>685</X>
                           <Y>127</Y>
@@ -536,7 +536,6 @@ if robot:
                           <X>736</X>
                           <Y>199</Y>
                         </item>
-                        <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                       </items>
                     </chunk>
                     <chunk name="ParameterData">
@@ -570,7 +569,7 @@ if robot:
                           </items>
                           <chunks count="1">
                             <chunk name="Attributes">
-                              <items count="3">
+                              <items count="2">
                                 <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                                   <X>687</X>
                                   <Y>129</Y>
@@ -581,7 +580,6 @@ if robot:
                                   <X>705.5</X>
                                   <Y>139</Y>
                                 </item>
-                                <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                               </items>
                             </chunk>
                           </chunks>
@@ -602,7 +600,7 @@ if robot:
                           </items>
                           <chunks count="1">
                             <chunk name="Attributes">
-                              <items count="3">
+                              <items count="2">
                                 <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                                   <X>687</X>
                                   <Y>149</Y>
@@ -613,7 +611,6 @@ if robot:
                                   <X>705.5</X>
                                   <Y>159</Y>
                                 </item>
-                                <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                               </items>
                             </chunk>
                           </chunks>
@@ -634,7 +631,7 @@ if robot:
                           </items>
                           <chunks count="1">
                             <chunk name="Attributes">
-                              <items count="3">
+                              <items count="2">
                                 <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                                   <X>687</X>
                                   <Y>169</Y>
@@ -645,7 +642,6 @@ if robot:
                                   <X>705.5</X>
                                   <Y>179</Y>
                                 </item>
-                                <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                               </items>
                             </chunk>
                           </chunks>
@@ -666,7 +662,7 @@ if robot:
                           </items>
                           <chunks count="1">
                             <chunk name="Attributes">
-                              <items count="3">
+                              <items count="2">
                                 <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                                   <X>687</X>
                                   <Y>189</Y>
@@ -677,7 +673,6 @@ if robot:
                                   <X>705.5</X>
                                   <Y>199</Y>
                                 </item>
-                                <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                               </items>
                             </chunk>
                           </chunks>
@@ -698,7 +693,7 @@ if robot:
                           </items>
                           <chunks count="1">
                             <chunk name="Attributes">
-                              <items count="3">
+                              <items count="2">
                                 <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                                   <X>687</X>
                                   <Y>209</Y>
@@ -709,7 +704,6 @@ if robot:
                                   <X>705.5</X>
                                   <Y>219</Y>
                                 </item>
-                                <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                               </items>
                             </chunk>
                           </chunks>
@@ -730,7 +724,7 @@ if robot:
                           </items>
                           <chunks count="1">
                             <chunk name="Attributes">
-                              <items count="3">
+                              <items count="2">
                                 <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                                   <X>687</X>
                                   <Y>229</Y>
@@ -741,7 +735,6 @@ if robot:
                                   <X>705.5</X>
                                   <Y>239</Y>
                                 </item>
-                                <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                               </items>
                             </chunk>
                           </chunks>
@@ -762,7 +755,7 @@ if robot:
                           </items>
                           <chunks count="1">
                             <chunk name="Attributes">
-                              <items count="3">
+                              <items count="2">
                                 <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                                   <X>687</X>
                                   <Y>249</Y>
@@ -773,7 +766,6 @@ if robot:
                                   <X>705.5</X>
                                   <Y>259</Y>
                                 </item>
-                                <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                               </items>
                             </chunk>
                           </chunks>
@@ -789,7 +781,7 @@ if robot:
                           </items>
                           <chunks count="1">
                             <chunk name="Attributes">
-                              <items count="3">
+                              <items count="2">
                                 <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                                   <X>751</X>
                                   <Y>129</Y>
@@ -800,7 +792,6 @@ if robot:
                                   <X>788.5</X>
                                   <Y>199</Y>
                                 </item>
-                                <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                               </items>
                             </chunk>
                           </chunks>
@@ -828,7 +819,7 @@ if robot:
                   </items>
                   <chunks count="2">
                     <chunk name="Attributes">
-                      <items count="2">
+                      <items count="3">
                         <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                           <X>420</X>
                           <Y>138</Y>
@@ -839,6 +830,7 @@ if robot:
                           <X>420.5246</X>
                           <Y>138.3925</Y>
                         </item>
+                        <item name="Selected" type_name="gh_bool" type_code="1">true</item>
                       </items>
                     </chunk>
                     <chunk name="Slider">
@@ -849,7 +841,7 @@ if robot:
                         <item name="Max" type_name="gh_double" type_code="6">360</item>
                         <item name="Min" type_name="gh_double" type_code="6">-360</item>
                         <item name="SnapCount" type_name="gh_int32" type_code="3">0</item>
-                        <item name="Value" type_name="gh_double" type_code="6">107</item>
+                        <item name="Value" type_name="gh_double" type_code="6">0</item>
                       </items>
                     </chunk>
                   </chunks>
@@ -894,7 +886,7 @@ if robot:
                         <item name="Max" type_name="gh_double" type_code="6">360</item>
                         <item name="Min" type_name="gh_double" type_code="6">-360</item>
                         <item name="SnapCount" type_name="gh_int32" type_code="3">0</item>
-                        <item name="Value" type_name="gh_double" type_code="6">22</item>
+                        <item name="Value" type_name="gh_double" type_code="6">0</item>
                       </items>
                     </chunk>
                   </chunks>
@@ -939,7 +931,7 @@ if robot:
                         <item name="Max" type_name="gh_double" type_code="6">360</item>
                         <item name="Min" type_name="gh_double" type_code="6">-360</item>
                         <item name="SnapCount" type_name="gh_int32" type_code="3">0</item>
-                        <item name="Value" type_name="gh_double" type_code="6">-27</item>
+                        <item name="Value" type_name="gh_double" type_code="6">0</item>
                       </items>
                     </chunk>
                   </chunks>
@@ -984,7 +976,7 @@ if robot:
                         <item name="Max" type_name="gh_double" type_code="6">360</item>
                         <item name="Min" type_name="gh_double" type_code="6">-360</item>
                         <item name="SnapCount" type_name="gh_int32" type_code="3">0</item>
-                        <item name="Value" type_name="gh_double" type_code="6">-95</item>
+                        <item name="Value" type_name="gh_double" type_code="6">0</item>
                       </items>
                     </chunk>
                   </chunks>
@@ -1029,7 +1021,7 @@ if robot:
                         <item name="Max" type_name="gh_double" type_code="6">360</item>
                         <item name="Min" type_name="gh_double" type_code="6">-360</item>
                         <item name="SnapCount" type_name="gh_int32" type_code="3">0</item>
-                        <item name="Value" type_name="gh_double" type_code="6">-11</item>
+                        <item name="Value" type_name="gh_double" type_code="6">0</item>
                       </items>
                     </chunk>
                   </chunks>
@@ -1074,7 +1066,7 @@ if robot:
                         <item name="Max" type_name="gh_double" type_code="6">360</item>
                         <item name="Min" type_name="gh_double" type_code="6">-360</item>
                         <item name="SnapCount" type_name="gh_int32" type_code="3">0</item>
-                        <item name="Value" type_name="gh_double" type_code="6">40</item>
+                        <item name="Value" type_name="gh_double" type_code="6">0</item>
                       </items>
                     </chunk>
                   </chunks>
@@ -1170,9 +1162,9 @@ from __future__ import print_function
 if robot and configuration:
     configuration.joint_names = robot.get_configurable_joint_names()
     robot.artist.update(configuration, visual=show_visual, collision=show_collision)
-    
+
     joint_state = dict(zip(configuration.joint_names, configuration.values))
-    
+
     print(joint_state)
 
     if show_visual:
@@ -2073,7 +2065,7 @@ Whether or not to show the robot's end-effector frame.</item>
                         <item name="Bounds" type_name="gh_drawing_rectanglef" type_code="35">
                           <X>883</X>
                           <Y>169</Y>
-                          <W>154</W>
+                          <W>226</W>
                           <H>22</H>
                         </item>
                       </items>
@@ -2158,7 +2150,7 @@ Whether or not to show the robot's end-effector frame.</item>
                     <item name="NickName" type_name="gh_string" type_code="10">show_frames</item>
                     <item name="Optional" type_name="gh_bool" type_code="1">false</item>
                     <item name="SourceCount" type_name="gh_int32" type_code="3">0</item>
-                    <item name="ToggleValue" type_name="gh_bool" type_code="1">true</item>
+                    <item name="ToggleValue" type_name="gh_bool" type_code="1">false</item>
                   </items>
                   <chunks count="1">
                     <chunk name="Attributes">
@@ -2189,7 +2181,7 @@ Whether or not to show the robot's end-effector frame.</item>
                     <item name="NickName" type_name="gh_string" type_code="10">show_end_effector_frame</item>
                     <item name="Optional" type_name="gh_bool" type_code="1">false</item>
                     <item name="SourceCount" type_name="gh_int32" type_code="3">0</item>
-                    <item name="ToggleValue" type_name="gh_bool" type_code="1">true</item>
+                    <item name="ToggleValue" type_name="gh_bool" type_code="1">false</item>
                   </items>
                   <chunks count="1">
                     <chunk name="Attributes">
@@ -2220,7 +2212,7 @@ Whether or not to show the robot's end-effector frame.</item>
                     <item name="NickName" type_name="gh_string" type_code="10">show_base_frame</item>
                     <item name="Optional" type_name="gh_bool" type_code="1">false</item>
                     <item name="SourceCount" type_name="gh_int32" type_code="3">0</item>
-                    <item name="ToggleValue" type_name="gh_bool" type_code="1">true</item>
+                    <item name="ToggleValue" type_name="gh_bool" type_code="1">false</item>
                   </items>
                   <chunks count="1">
                     <chunk name="Attributes">
@@ -2482,7 +2474,7 @@ Whether or not to show the robot's end-effector frame.</item>
                 <chunk name="Container">
                   <items count="12">
                     <item name="CodeInput" type_name="gh_string" type_code="10">from System.Drawing import Color
-from compas_ghpython import draw_frame
+from compas_ghpython.utilities import draw_frame
 
 red = Color.FromArgb(255, 0, 0)
 green = Color.FromArgb(0, 255, 0)
@@ -2798,7 +2790,7 @@ W = 3</item>
     <chunk name="Thumbnail">
       <items count="1">
         <item name="Thumbnail" type_name="gh_drawing_bitmap" type_code="37">
-          <bitmap length="7926">iVBORw0KGgoAAAANSUhEUgAAALwAAAB9CAIAAACXn57tAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAB6LSURBVHhe7Z1ndFTHmq7PWvfv/Jmfd81dM/eumXPnnHXGPhhjMGBsbET0YIxNMgZsDAaOTRBBGeWMJJTVEso5ByQkBIqggFIrZ6kVQEJZQkIih3m6dyNLIm6bOYztele5Vu3atfeuXfXU933V3cJ/EBL6OXosJPTK+gmaa0JCryABjZBsCWiEZEtAIyRbAhoh2RLQCMnWK0HT8yxpzwn9/jQLmoEZ6u3t5TRwdHZ2djxRV1eXhIsGG8HN71SzoCl9opKSkqtXrw4PDwNKW1sb5e7ubihpampKS0tLTk7OyMhoaWmRwBL6vWkWNKEahYeHKxS+gYFBVVVVINLY2AhGSqWSw0uXLu3du9fT0/PkyZPU9PX1aW8j9HvSLGiWarRkydL3319sZmaRm5sbHBx8+fLlxMTEpKQkcrR48WJ9ff0tW7aUl5f39/drbyP0e9IsaFxd3TXJzcXFta6ufnJysqGhAXQkh4VpSU9P36TRvn37BDS/W82C5sYTjY/fkFwP0QyxS3Nzs5S3trYSC6tUKmIdAmQRC/8+NQsabd1sEe3O1PUnEsT8bvVyaISE5khAIyRbAhoh2RLQCMmWgEZItmZB0/3fLOnrCO2ThX61mgXN7du3NR/SaDUxMaEtvSbdvHmzv79/DjcanP7HCb61/RN6SrOg6ezsJL9z5w75vXv37t+/f/fuXWZ68jXp1q1bg4ODTIn24ZoPD7Uf+zxHfX192tLfV/RtZj81IAlpNQua7du319XVMWTBwcEtLS3ffPNNaWmpxM1r0dTU1ExoIKa3t5dKAOXpjx49AiwOJVGG2gcPHpDPrJ8p6rlW4ltbNUOc/XkC7pGRka6uLqmfFOg2dpdTWGLuLJnkORobG+NClhwNKGtrn4hLsLXag1+5ZkFz8ODBHzU6efLk4cOHv/zyy5qaGkZBO+e/WIzm09Bwf2bFzMzs/Pnz9EEC5eHDh5QLCwvpycWLFylLZEAwkkjibtRzbUdHR1paGjNKvST4oxnTrH2wTHGr4eHhmdAAARhh9rgt/WdpSU+hV9SQU6Yzra2tjJhKpZI6LFVSIG9ubqY/FKT+U4Aw6Vm/OtH5n6DZuXMnk+fo6Lh///7w8HBDQ8OsrCzeWRrKX65nQsNzeZyPjw/D6uHhwUNzcnLA19vbW1dXd9myZc7OzqmpqT/88IOXlxcApaSk+Pr6Wltbh4SEcEpPT2/dunUnTpzIz88/cuQIZ/38/Pbt26dUKn92zxmXOdAw3+3t7YcOHaqurqZXDA73Lykpoc9tGsF3bW0tfTYyMkpOTpZOFRUVVVZWBgYGmpqaMqqY8Pj4eO4GWElJSUNDQwyI9pG/Ks2CprGxkUnFkPL+LAhekgl+jS/2NDQ8gudu3boVM8N87Nmzx8LCYsuWLcbGxvr6+iYmJkBM4fvvv2fCXF1dsX/Hjx//7rvvYmJiMEI6OjpMEvNhYGCwY8cOBwcHWmIpocfFxYU7ax8sU09Dg5nBbAAojw4NDbW1teUpPJceAoqNjY1CodiwYQMdACkOcfSJiYlQ/tlnn9FzKnkLXoolAd9c+/nnn4eFhf3sHr5ZzYIGULCZDJm0RqFHMqHT4pS29JRecGpaz7Q0PIt1eeDAgbNnz2IkgCY7OzszM/PcuXPSTwRZnZs3b964cSNWhGmjTUJCAg4CY8O05eXlkcfGxmIUjx07duHCBcxSeno6NgkXpn2wTD0TGsYHUt96662enh7mHvsB4vQBLKysrODg66+/PnXqFHCcPn3a0tISvnkp1gNGFLacnJykZnZ2dpR5C/RbgIb5Y6CnNdO8M46YaFy7pJs3Jx7exwL9VIMI9GaiAyIwN1NQ+DQ0tJR8PI9jNSMOp3tCmTwuLo6lzHadZjSghkiIuEcqS23IpWspI+4wHdPQK7l6GhpehxiQMi+CgWxoaKD/1OOAaCw5qYGBAU7xUjggKvFoRDmMTH19PajRHzYW3IQXQTR+jVb876lZ0FRVVeOqGQVUUVEhOSlGnxyxIWdE1G/b31dTXekZUlxW3TnQr94VSxtjxogRYdpoTE6ZkYISSZQZPiqvXtX+3IKavr5+WIIudZqcmdj8sP2Zmrypzukbun3rtrbXcsTdbozcvDGqTZMam8h/42OTM+t/SiO0Yfc0FxouYY55Ne4J/RQAF4AAlFw9QBo7zSk0XcnocRU5lRQYFnKpDQ2kHv7qxFz8BI23t8Lf/4ykgIAAPHRKylnp51e4DBxBeXl5bm5udVWltU/1Vr34DM9vG2uUefmXpF/30RKHQmCEaEmYQgE3wVmi1LbWNiLcCmVFG8uvrbmltamptaG1vWlwpH9orH+YdKN/cPQ6aWisj/LwjYGR8YHR8aGxieEbN0fHb45NTI7fnJyYnMKGzdmBw9xPYuLuTN2/M0l68OD246bu2srerJqBvNrB/Kre3NSCpOi06LjM2CuqC9V9eZW9uXMSbaq7rgwPjUxbxGlotGP2u9csaJYvXzFv3jsLNJo3b97y5R8TZzQ1NTH3xApsawk1oqOjLuYW2TtGXDL7XxfsdfLyCpKSkwk7aAA3xBaYYlRWVka5oKCAOCAiIiIqKkr6rXFFRXlrW0szxLTUNzTXtaqa2jubSyuLy6tLCkpzy2uLlA3FFfWF5fWXy+rzS+pyr9RlXam7WFyXWVR3vrj+QmljtrLlkrLpcm17SWOnsq6torG9qllV29LRQGrr5G6tje3VtQPZ9UPZNcOZl+tTXFP0/Xq22BSsdyjZoFBt2eu4+VvL77Ybbfdt25H0aHfc7bkp5v62s1fth/vGBTTP0yxoUlJSExKY2SRSXFxCZuYFzKwUJZDjs7AfVVVVysqqK/lp8W6GF7IuKauqKivVHg13BiIMLoEF1picMraHEWf0yfHuOCn8+hP3dL2np3dsdKyxsdXNNdDNNSghPkPVrupQdXWoOjvaOymo2jqkXNXe2d6m4mxbW3vm+UzwxXphyfCYbW2tLa0tUt7a1trR0XHlSnFonG/naE3fjY6R4ZF4pdvpgSXOHcvdej5RjK5ae3zJl2abVv24yr5OJ/DOar/xucn75gcxncYj/TcFNM/TLGiYbPiYFi6ZwZI0OjpKzqwPDQ2RD4+Mjk3eo1aq0VYOD0vNJBHBgMgcEfrMDIS5pL6+ydzc2cbGw9s7qLCwsKioiPyZ4hTCpLFRwuZhBa9cuaI990Q0yM7KLi8rvz7S2Xi9uO1qTXiho+/NFYGT/+nWvdKzd/UGo+W7HHat+tsqh9rVQbfWnRmbm3zGl8d2mDwTGrnc/FY5mwUNw/Q8SQbjVfSCltIpaSYQ0LCDIBzOy7ucn18IDDgvLNnzRJCO8H3sTRBxOhZOe+6JqFFWKol5Ht59fOvWVENrtevZ4343dc6MrbWu+tD96sq1x5Zst/l63ZF1dlUrA6fW+o3OTd43PorpmGtpWAwQIAXyLxXNpAUjBb+/PXRmQSON0d9NkqWpq2t0cvKzs/OMizuHN5r+K2CpMDPHxmBLkpKSCMyf14x7lpWVR0aH9Y60Y2zuTz3OaPJ3G1rqO7Laf2Kt7/CaVUcWbTLdsmL/CpvKFf431yiGV89JnqPLolSGM6GhQD+5P/SQz6yfXgY8F3E4nQM3FhGy2WT9xrh549AMNTY229i42tt7enkF5OWp91ls056pjIwM9mKpqakvaINo09jUOHSjTzVUVViTbhW1TzH+iWJklX7eIquqD1Yeee9r2x0r/6ZjVf6x3/gq78GVc5L78NKIdv050PT399fV1ZFDbVxcHM4xJSUlPT2d/SAbxoSEBHwluwEqi4uLpQ8maLlhwwb2ASEhIb8xbt4wNLgn1mpGRlZ6OukCzoWlOe19Zuaourpa8kHMx9MNpnNCcsLsu7fv3b/9+PGtxyl13s59i7wGdDwHVngP6iz/2/wNBhs/2vORZflHAVOrfEdXKmYkDt1HlkS0600OP+jp7uu5pv2NBJYGGtgAwivEwCVhuJRnZ2dTgB7sCofsI2jAnoBOwhDWkZfCSWnH+9ejW5rvBmZq+i3eMDQjI8M1NfVmZi6GhvZhYYlsgtr474nYfHFIThnXM21mmJ45zaZz3Edx8ZXQ8OCuwYaW/rLathLXc8dxT579n5grF1vVLP3k0LvENMu//0g/Z7FF5WL9vPf08t4zK19sXLxIP3+hUeEix673T13anlOUUX+tqLWrrudaL/Swy4Mb+owVkT7JJMrhWdLnEQhYYSU8PDwqKop+4ptoxpIggmZ7IY31r0LAQYfZLBNrSn6Wl+XFeVnMp/SB5BuGhm1Xa2u7p6e/r2+or2/gxYsXWLgwMUdssBGrmZy1+8w2kpgwNDQ0zLIYnRjsvqbyyTJ26Vvkdn25RdVih5YPPj44f73ehkVfL9LLed+y+n1z5fsGl94zKlxoWv6+adkik5JFDp0LnQt3FpXnKbsuFLedLWxNLm/JGRweuH/nofQxLmJrCRbgS3TF4MITm0cJEelHM+3t7Yw+LV+7jZE68OqizzhHpD1+SjN7CC50ngUQHR2NyeS9GOq0tDSsOy/IesCEc8kbhoauqFSdKSnn4+PPYulZuBrboZVkPJgAPA5ig42DkL7QkU5JmmlpsEBqB1ZdOTYxPDI+eHNsKrrcyeHa/NM9Hzp3L3NsX7rswNsbDDe+t+0946LFirGP3fuXe2gSBansdH1BaIvu1OjD3u6Bvh6w66pqK1R2XuwcqJ+YGL89dZetGYNbVlaG2SsvL4cbXoRFOS3cWUNDg/Tz1tcoiULQvH69F2P3woSRwy6oxTTTPc03NmoTOSdxK2ljCDpYF1YCERuDzBCy9hhwHC5OFnSKiopYtCBF4zcMjeSe9PVtDx82VSjCamqqpgOXafEm9BuBPCEn60B74lkiXM3Ly49LiLk23NY6WF5Sn2UeuZuYxuXasqNZ84yKFyza8++fG25c+PVCDIx7/zLn7g/mJIer7wQ0HBwdmHwSCPf0XL0+MjLaPdTceK2k43rT4EjfjfExxo4QStXerurowIKzc8OAI9woos+vFxoexw3xg3l5RWVlNaWl1S9IxcUV+fnFBQWlly+XBgUFe3l5eXt75+YWVFc3KZX1FRV1paVVUsuioora2gamHhsJJQT12H4OEW/BULMkVCoVi5mx5RQWi85w9k1CMzQ02NbWHh4eGxubEhwcDtHSzmhmjogrJZWWll7S6Olm041ZEJM3px7cfXzv1qPHdx8n13tYtv+HU+dS174PXHqWvvP1v35h8uWSb5ccz5nv1veBU9fSOcmue55//Q8zoNF+uHfnljo0uT7U3Xm9uWeg41JBLgacLpUUFJSlp3dfvQo9kqlDoI9fwCBJ31k+LeqZAMnfscphAmnweLZow5yFhYUFBMTExV2Micl8XoqPv+juHmRsbGdu7uTpGXrgwI9r167ZtGmTm1uAu3vw6dP+JJrFxkqNsxSKwOTkJHBhbB8+fEiv6L/0UxPcEzmbRNDBTOGzpA853zg0Q3gkX99wNzf/1NSLrFRmSFqsUmFmzlmMDbaEqWLNcfnTzaisVFYmpST2jLS3D1aWN+SZR33reO1dp+4luhf/ql/wzvxdamgWfLXgWM47p/uWOHYsnpNsOt8+U3fgaWikSZ3CRUzdxkOx7svKy2Ckrr7edsMG8717C0pKWKyRkZFsl6QdONOAhWfbVaIRHg0nq1QqMVGsXeaGXuM48Dj4iImJCchgznAT0q8+EJNCWeKMQIrGoaFJERHnIiN/SprD9CfQnIeG2NgL5LBFvnv3Xh2dFWz+3d0DFIpIV9cAL69Q2j+5Nj00NKqhAc+r/ikqL8u6pXvUUKDDuCe8MKuUzSDDLlH+hqHBPdXXN5qYOJianvLw8Meb0jPy54mZ4GWYGyzKM1vybhcuXLxSUjw6MTA41js2MhpcaGnZ/hcH1ftWDe/ZtSx8+6t/WX1k7VtfvHU0e55L72Lq5yTrjrd8a/c9DxpJ0nKE4IrKyoqiovO2tjnp6dW1tTCB72fQMXvEWNK+g9fkVtwE6LkKa4SpV38hUlSEcWQpE9qz88rQSPrpWVJScmoqtz9HDS/FbeFPqazA0vj7x2gmO206QUBQUIK9vZelpYupqYOdnQdlCwsnK6vTHh7Be/bsA5r169f7+IQnJuZihyApKkoNDdcGBCReuVLB1EsBDd2gw+qveyYment7qKHDUucJJVnhBEmYnDcMDYuMPmVkZGVm5qSmnistLVFHvM8XgSc5S1k6fFo0YHxvjN24fevO+M2xvr5eryw9i/a/2KsWGpW+Y1Qyb96O/7fJbPPbX7x9KPMtp2uL7NoWzkkQ5lOz98XQsOA03c5QR2CVlfXNzQ3NzbCCFSQEpkAPaYPlYF1OixqEwaitrb98uezChbxLl7BDSvxbbm5hdvbl/Pwr7An27v3+4MGDO3fu/Oabbzdv3qyrexTIsDHMGeYqMDA2PDwtPDx1RkoLDk7y8grz84v28AjB+8CHj0+Et3d4YGD8N998t3z5R59+ug4bc+ZMrKdnCPaGU0FBiUATEpISF5fc3NyELQFi4tz09OyIiMTg4BhyJoVZYh0CEyaTEEfahbx5S4MttLX1NDKyi44+q/4iWyM6NyfH+wAEuz7WJV6Wa5/ZjAkuKSkNiwjpGmxo7i+paik0idxm2PZ/TFv//970f/ox/5//bfM//t81//oP8//h+/P/bNn17yeb/zgn6bf8bxflltGBqRdAQxl/jw1gFunVnOAdYjDsLFZt69l69OhBenqOpaWHrq6pgYGNuflpS0s3AwPbY8csHB397O29P/zwQ7zJunXrIOaTTz754otNvC8+jnXP44hpQkPPhoamzExhYdQkE8rASmBgAomCr28UfGzdul1fX2/37t2Wls42Nu6YH41BcoQbCbjTpz1zcrLZZGFsxsbGXF39dXUtDh0yPnbMyt8/vKWlifjGz8+PFYJp5+1YmW8YmuHhoebmVlfXM+7ugQEB4cAuBQFPi3rOTofAL2hGg/b2NvWinrrz+P5jZVeuf6VuaI1RZJNJVLOJZbjuEfv9Bl6HAsoMw+uNqZ+TgqqPZzaFjI9MsneW+vk0NISxGBWcBb4SdOZYPjCiJ8+EhkosfHZ2np9fWGhobHBwdGBgZHBwVEgIKMSSe3j47d69Z9eubzT5t1u2bFMo1D8l5kJWRWhoqI9PGOYB0zIzwY2vbzS+ieDXwcH79OkAKytXzV9AKIDGwcF+7969Tk6KqKjzgAJh5CEhyVzo6xuTk1PA/TGEdI93LCgoOncOy5KN+c/IyGTMCwuLeB0pJsPqsELeMDTkmETQ0fy24slnC88X7kwSnlVbNVvUcy/en9BSo5HJ8Vu3bzy6NfZQSg/uPnr88PGj+49vj2tr5qTbY49uTdzrH+iHFamfT0ODGGXgAFDW3xxRySl8k7bpE3EJ3bt48TIhf2oqE5OLP8rIyElMTEtPz6KGHXJGRraZmZment6hQ4eOHj165MgRCwtLAOWV8Wvkfn6RgYGJkjmZTgEB8bgbDRCpoODvHwdGEhnbtm13cnLaseNrW1sPTBTNSNMXKhTR589nY/y4OauMTlZW1lZVNZKqqxvr6lrT0jI9PT3ZtEdGxtC98vK6wsIrbxIahAuY9gIIjF6LpNv+Qmn79BxopEMtmU8JwzCnPWJWCE0wA/r6ameESzIzc9HXtzl+3JL86FFze3uFlZXbypUr165du2KFzpo1a3R0Vm7ZshV7RqDGKvf29vHwCAoISACL6QQEFhYux4+bY1pOnVJgbPT1LY2NbQ0MrOzsvDZu/NLExHjPnj0nTpjr61txiuTk5MdVmmuT7OycY2KisSUAPTk5kZBwDksmba/YddjZua5Zs3rlSp1Dh455eoYlJOTY2jq9YWh+FXomNIiaF0jbaIaoxKyeP58VF5eSkpKRlHSOIJQ8OTldyhMSUiMiYqytbS0srMitrKyNjU+eO5fO1EibcDyUt3eonx9BRsx0IrwlglEoovBQRCre3hE0oKxJMZ9++pmu7pGvvvrK2tqVGuJl5t7HJ5KruNbbOzI+/mxPzzXid2Kc48chI4DQx8jI5uRJNmKeFhaOq1atXLHiY6CBIQ1PCQKal+t50PwM3b3LXr29qKg8O5vwjAhMmZdXlJuLRyNcK8YppKae19fXNzc3x0MZGRnhnry8vDF79AFiUlNT3dwCQQFEphMoMP1EuObmzg4OPlgRTA62h4CX8vr1n1tYmBNTW1u7Ec1gXSTvRoFrXV2D2bgx9UTZCoWCbVR0dIrGksXi8nBnxsbWO3fuMDU9uXv3Pje3IGrc3RUCmpfrtUDD5cQ0mIyCgivW1l66uiePH7c4efKUiYmDZqtifvSomZtbCLvIZcs++Oyzzz799NMtW7YsW7Zsx45dOTk5SqWSyObs2bOaHXUUpkKTIigTl1Am8gUavBsuycLCGSfFIYHwunXr9+/f9/nnn+vpWWBCiGyMje14KO25yts7Cgiys7MSExPZGcFAfHw6hkqKe8LDz+npmW/f/pWlpcWuXXvxZWfOxAlL80r65dBw7fj4eKv6X2HuLioqYTUnJOCSzpPHxaVRSE7OJFFQKIK2bt22adNmdtobNmxct+4/vb3VK1uSSqXSfKQb4eUVTsITubkFOzv7k1P28AjF9Xh6hrq7h2gK6gQ0Cxa8u2TJEjyOtbU7SMGTmZkThodLPD3DPTx82W9jaTo7O+/fvxcengiIOC9MEWG1rq7R7t3fGhsbbdu2i/YKRUxQUCQ9EdC8RL8cGmwMe8O0tOyAgGiFIiQ6Ojk+/lxAQATbbApsvIOCokjp6blgxCQdO3bs++/3soHatWvX/v0HsrKypECYXYyjozfQSEBgKjAnhw4ZnjhhQQHrdeSIMYbEyMj2yBETXV0Tc3OXdes+e/fd+YsWLYQSHBOX4N1wZ5r4JuLUKf+srEtMPc6SDURsbIyLC25K/SEhzgguDx7U27Ztq67u4U2bthPCc+2pU+4CmpfrZ0Oj+SYSM8O+Sf0nm25u/oaG9np6VoaGzKv9iROWlPFHT8rW1tYeOKyPPlq+evXqNWvWrl//2bJlH+7Z831jY2N/f/+9e/euX+9zcTnj6RnBomdGsRNEspLVwdiQU4+ZweQAB3NPjY7O6vnz5y9cuNDQ0NrFJeDUKV9n5zPYGzwX6dSpMxERcUql+mcn2MKIiHA7Ozcfn+iTJx2PHTMzMLA5dEh/3ry//vWvb2/f/g3EuLgExsenCmherp8HDdals7OroaGppaWttVVFnp2df/58dmZmDnl6+sULF3JJbKYyMrIuXswjcSo2NlFPz+DYsROHD+sePHh4374DYWHhTA03xDeFhIQQ3urqmmJaTE1PmZo6YVGYYEND2x9/JIC2ZqYxORwePWqqKbusWLGKWV+wYAENqDx82JiAhgL2Ccvk6OhrYWF/6VK++rNQ9d8a3zlzJgIyIM/dPfTMmfj9+4/++c9/+stf/rxx4xbu7+Dga2ZmJ6B5uX4eNExAUVFpcHCCvb2bm9sZHFNAAFHnmeBgdsghDg7ufn5hXl6BxBDe3kEeHv7sdRMSMiMjk4l/f/jhh507dx44sJ/yzp27iH8LCgpqamry8/NhxcDATrJVwGFgoE4cGhs7amrUp4yNHfT1bSiYmTkvXfrhH//4xz/96c8YM5yRnZ039ozczs6HZGLizJabqeft0K1bU8HBMba2nhgkEh7q8GFD6X/Ms3PnHtyTjY1HeHisgObl+nnQPHhwH+NhauqMPSDwZP6Yb3IMAwbAwkK9Q+aQxKFkNuztfWj54YcfrViho6OzEg/FbO3f/zf6gBm4r/m3Mmpq6pTK6srKmhemnxoUFhbn5ubl51+uqKisqKiak0pLK7q7r+I9pT7jTwfUP/XvolJK1671SAldvaoeitHRUQHNy8VIDQ8PM6YTcgRkg4ODra1tKlWnStUxI805lJK6sl3zd8fNzS1NTc2kxsYm0vXr12FFuid9uHfvLnucV08PNf8Q3SP1v8ky95Qm3YcY6eaSNL/pkZyVVjxdI6ms/upeQPNySd9LaA9eWVzFVnb6t7qvKNqD2kz19fVxK+1N/2dIQCMkWwIaIdkS0AjJloBGSLYENEKyJaARki0BjZBsCWiEZEtAIyRbAhoh2RLQCMmWgEZItgQ0QrIloBGSLQGNkGwJaIRkS0AjJFsCGiHZEtAIyZaARki2BDRCsiWgEZItAY2QbAlohGRLQCMkWwIaIdkS0AjJloBGSLYENEKyJaARki0BjZBsCWiEZEtAIyRbAhoh2RLQCMmWgEZItgQ0QrIloBGSLQGNkGwJaIRkS0AjJFsCGiHZEtAIyZaARki2BDRCsiWgEZItAY2QbAlohGRLQCMkWwIaIdkS0AjJloBGSLYENEKyJaARki0BjZBsCWiEZEtAIyRbAhoh2RLQCMmWgEZItgQ0QrI1CxohoVeUFhohIRn6wx/+C7LiljJBgKUtAAAAAElFTkSuQmCC</bitmap>
+          <bitmap length="15950">iVBORw0KGgoAAAANSUhEUgAAASwAAADICAIAAADdvUsCAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAHYcAAB2HAY/l8WUAAD3jSURBVHhe7Z0HWFRX2sf32/12N/vFbJJNTza7yaabGI1JTNRYYxJTTLHE3rB3UUFQEARBmvQOKqBSbICAig1RBBS7a9QYDRIjzZpYYlu/H/NeJ+MM4BCFkfX8nvvMc9o999xz3/953zMMM79TKBSW55pCobAQv4rwB4VCUecoESoUFkaJUKGwMEqECoWFUSJUKCyMEqFCYWGUCBUKC6NEqFBYGCVChcLCKBEqFBZGiVChsDBKhAqFhVEiVCgsjBKhQmFhlAgVCgujRKhQWBglQoXCwigRKhQWRolQobAwSoQKhYVRIlQoLIwSoUJhYZQIFQoLo0SoUFgYJUKFwsIoESoUFkaJUKGwMEqECoWFUSJUKCyMEqFCYWGUCBUKC6NEqFBYGCVChcLCKBEqFBZGiVChsDBKhAqFhVEiVCgsjBKhQmFhlAgVCgujRKhQWBglQoXCwigRKhQWRolQobAwSoQKhYVRIlQoLIwSoUJhYZQIFQoLo0SoUFgYJUKFwsLcIMKj9QpGr08oFPWXG0S4p76xc+fO77//XulQUa+5QYSn6xVnz579VocSoaJec4MIMet6xC+//HLo0CElQkV95wYR/lyvuHDhghKh4r8AJUKFwsLcpSL8UaGoTTQ7M4+7UYS0P3DgwL///e+9CsXtBrvav3+/ZmrmcTeKsKioaMeOHdqSpVDcVo4dO7Zz587CwkLN2szgbhThkSNHWLHOKxS1wC+//LJv377vv/9es7abgfXepSIkZtB6UShuK+fOnfvmm2/MFyHOU4lQobidKBGahRKhovZQIjQLi4uQkbNz4GlpecV/EUqEZmGOCOn8ypUr//nPfy5evHj27Fmt9JbhCTHPp0+fLikpkX08WeByP/30k9bIQjAA/XhYIyw+nnqKEqFZVCNCLI9umQp0snv37i1bthQVFZG9fPnyrRslj+fSpUsuLi4vvPDCQw89NHz4cPp0dna2t7dnVFxXa1dXsLhwXwxJsijw+PHj06dPt7GxYWLRoZQraoQSoVlUJUIkgUVimhjiSy+99Pvf/55pefDBB7t167Z///5bN0r86sKFC2W2//jHP3bu3DkjI0OywcHBdTz/3Cb3e+DAgcOHD4urZwBpaWkyHjc3t3pnD3cISoRmUZUIxRd98MEHMiH/8z//8+ijj0p60KBBhvNDS+SKLI0iVbL4E0nThlCWRyJZoAcrKyt6Q+E4WDTAMF5//fVXXnllw4YNRL/SjE7oGeiK00GuIp0bXpEq/eVAn+XVMIqmnCwDlhsUGMzatWv/7//+729/+xtLDAvE1atX9+7d+9prrzG8VatW6ccD0gMYXk6ghFoS0sbwEncnzIMS4c2pSoTMgIODg8xGly5d9u3bV15evn379h49ehChYabiKml25swZOikuLsZwDedNZCltTp48ybWwSzkRY6UQp0rnX3zxBWnKgQbEhNIGSFBVVlZG5yJ1GtCtdE4DSQMPmwZcTuxesrzSA69cWkRLb3Ry7NgxBsywyUp7Enq/t2fPHrL0LOMBGQ/N6ETfAwuHnEgPUkv/MgBpw0VPnDhBmgFQe3fCvSsR3pxKRYgJYvqPPfYYU4FrEsOikFcski0ibXAO2OKYMWOef/75v/zlL+zrcJuElLTBFhGktbX1q6++um7dOl9f32eeeebhhx9u1apVfn4+PWDB77//PsEt/fP6zjvvvPXWW2+//XaLFi06dOiACxIpbtu2DYn+9a9/xUe98cYbzZs3b9q0aVRUFJ2zELz88stsIEkzsJKSkvbt2+O4VqxYwcCwfvp/7733cnJyuChji4mJQSQeHh5vvvnmvffee88997z44ou2trbohx4o5y4YDA6fTpo1aybjadmyZZs2bVh6GA/2xK3RD4O8//776YS7c3R0lOniouvXr+dc+szNzeWiONV//etfhLJyrm5e7zqUCM2iUhFy+ytXrpSpcHV1JSuLPSAwZhazwzE2btxY2vzjH/+QTSMgA/TDKa1btyb71FNPSbnwz3/+k67YerEP1IpMoAdOZ2CyChCjogep+tOf/uTu7k5t27ZtyaJY0giAe//f//1fSsLCwijhWbIukH3kkUcqTvvd73x8fFJTUyXNsvLss89KeurUqbTv06ePZCtl8eLFtIEZM2ZICarWB+c9e/ZkANTGx8eTfeCBB1CyVAnz5s2jVmbvbkOJ0CyqEmF4eLhMRVJSkulsUDJt2jRqcSnYKJokisPdUYL3YO2nQceOHXUd/G7SpElstMaNGyfZ5cuXU1tYWPjRRx+Rbdeu3UEdCQkJ0mD16tU0CA4OJo1LIQ2ff/45WRQoFv/JJ5+QpZA0l+MxY/2UzJ49mxJctAgYCKqXLVtGOI0TdnJy+u677yq6u3bt66+/prZJkyYEnETLqJfsH/7wB7R64MABBpyenk6WwpSUFNpTIgsHqpNYYPjw4WQhOzubBosWLZIsHnLz5s3sJHGGZDt37kwti5dM3V2FEqFZVCXCgIAAmYrk5GSj2WBmMVzxTp999hm1EqkSm1HSoEEDBEZWREhYSBqw/j//+c+UENFJCdtLsrInhIKCArIgIiSQIy0yg/79+5MlCpWsmSK0srLSNb/GgGVpYLfGSJir8ePH0wCviGemPDMzkyyqQ666M64xmeJdRYSyKqFDomVpQD/ib4lmyYoIiQi2bNkiDbp27UoJAS2hgRKhOSgR/gq3HxsbK1OB8RnNBpI7fvw4gSW1EydOlFpe58yZQwmGu3PnTrIiwm7dupFGACiT3R0l9EwJiI2KjGHjxo1kQUS4a9cu2TQiv2HDhkkVe06JdUWEIuBqRBgUFESW4cm7JiwTsvfTg9eSweMtySLCHTt2sEvE3+7evdtQhASupB9//PHS0lJmANh5SrBtZ2dHAxEhPaBSeqBEolycOVklQnNQIvwVDD0vL0+m4ssvv2Q26J9y5pQ0nDp16rnnnqOWkIysOBMJIHEOxJZkRYRfffUVaXTCPvC+++6jxEwRMip2dPfff78UYu6+vr5Ys4zh008/pVBEiGDKysoqFSFbQbKMnNfJkydTgq5Gjx4dHR0t4aipCBF/pSJ0dnYmzVUwFNwpFBcXS8DJXpEGehFKD5T06tWLEvbGSoSatd0MJcJfwW/QobzvQnyFyTIhgJbYAaIirKp9+/bUEs4R6Untxx9/TAlmLX8M+M0iXLNmDdm+ffuSnjBhAo9w27ZtjIpCVgdJiIRefvllPBLZwMBArJ+SSkWIKTBIBkaJtbU1JeDq6krWSISwdetWaYCWDEWo37Lq36fRf9ggLS2NrBKhKUqEZlGpCIEZSE9P16ZD93ZL9+7d33zzTdKEgtRK8Akffvihv78/tZINCQmhFuR9F3GkIkK2i5To94RdunQhi0+T7IYNGyrOv+4Jp02bhv7vvffeRo0atWjRgquMGjUKNYp9y44R2HHhDyUNsl4gQnn30tvbmywC4Cx5t7Zp06aInDD1T3/6E9mGDRvKzebn51ecr7vTQYMG5ebmMp8ibNkV42wl+CQiRcBOTk4PP/wwWTqkfxqIJhkz0bgMsmfPnpSocFSJ8CZUJUJgElj+5T1PPZggroBoDV3hVcRMBcyakI8q8YTiKsXR0ZgnIX/G0ItQxIO6JJuTk1PRy3UR4pFEtE888YREfcAuUd4XIRR8/fXXpRAwd9RIIioqSmpl/+np6UmWe0EGmZmZ4ooFhM0rO1vkgZ/Eo3bq1EmqIDU1lcmRtIgQsrKyjGbjnXfe2b9/P7dMrd4xEseKCMVdv/vuu+qNGTG2m6JEWAnMQ2lp6dKlS7HmmTNnEnHJNFElSisoKCAUxGvhAHfs2EEJ5dQyns2bN2OXaIk0JnjmzBlcKyVFRUUS7lJFlmakKSkvL+dCS5YsIUFWHBc90ycK2bRp0z333EOJvNeCqktKSiIiIqZPn064iJVzdXorLCykNwaA5MiyO5UscBZ3yjhdXFxWrFjBkLjWqlWrMBRqucTp06fnz5+Pj42Li2PTSxYp0gm3zHhk38tFFyxYwEU9PDyIQukEvVFFA5rRmFNOnjxJn1xXhoRTpVbGcLehRGgW1YsQZNOlB6ehVej+cC/vVQqYo1ah+/y3eAO8BGlKaCzNGColIA5EjBh4YNKAcoQqf5RzdnamHCNGHuJ12bzRhvb6vSjQufTGaKniclJOG8kK0kagT0lIFc0YmJQAF9UPWBQozQwvCnp1GZ7OiWRBLscUkZZmdxtKhGZxUxHWPTy5S5cu9e7dW57FX/7yF3aGkh44cCAyoIHWVHFno0RoFnegCIHbwcmwe0R17C0/+OCDkSNHEnbiW6i6ax1LvUOJ0CzuTBEiM324aIjygfWLWxUhexVzwPq1C1qU/zIRGsIWC7SMol5xqyJcdzPWrl3LK2ca7f4twn+xCBX1l1sVYdbNWL9+/erVq4OCgrD+X2r4dQ8s7Wxv/nNrIH6tOyVCxR3JrYpQs/RqodmmTZvS0tJIa5c1AxTIhmfDhg3JycnLfhOpqakpKSnc3qVLl8QJKxEq7kBuVYSnzUD+iLx8+fIaiRAfiPzmz59f8FvZunVrfn5+cHDw7t270SF9KhHWX1hGAXvFiq7qPjsO8o5DvYNbMNyd3aoIi4uLT5w4UV5eXmJAaWlpWVmZlikpQYdsC/FptNdfuBpoI2/6zZ07lwSDvqyDEkGyYJQFeTBaRtcANa5atYoEPSsR1jsIiLAHTEis4vjx40Q3iYmJCxcu5DUpKYmEOeADIKMypEprV/swZsAI9RulWxUh+TVr1uBqMGvsm1fs9TsdZCVBISJs3bq1fNwRx1g9op8pU6YMGjSILA/g1KlTjPXgwYNsMulQIlWc265duw4cOEBj2lDCzdDy5MmTcgqgup07d3Jp5ppLKxHWL3jQPEqW+DM6MIbZs2ezpPIEee7yr/03hWbYTEREhF3VREdHYxhmdniLMHhsMigoCO1gtNzmrYpwx44doaGh/v7+ubm53MPSpUs3b97MEuXj41NUVMT1AAtGPIMHD37mmWfWrl2LbyysFiZ94sSJjRs39vLyojGXRDM8A2YqJibG19eXcWRmZqKKxYsXe3t7b9u2jTYonARqnzVrFn5YzmLhZDzDhg37xz/+sXHjRpykEmH9gslnVeU5IkjCrjlz5mB1rL/mQ3usztnZOTs7G4eBnRhCCeVOTk4SqWnn1DJcKC0tDcskzT3eqggRtIeHB6oLCwtzd3dPTU1lDxYYGMgrItyn4/Dhw8uWLUNONjY2TzzxxIgRIwZUzcCBA3n9/e9/v3fvXoIEfKx0wrW5hLW1Na4cKaJ2Lo3eWBoRJ5NICcsBoFKULGchOe6Wc7n00KFDGbASYX0BL8FjEhAhlspCzKMnnCE0NQKJUk4DLa+DHnjloWMVixYtYuFOrwykuGDBApG3nFjb4AxQChul2yNCvDzaY2q4T/kHAhLs5RAhnSIkIBhATnFxcTg3Gm/ZsmV9tbBCtGvXbvjw4bGxsXv27MH6gd5QHSV4XUTOhbg0/hZlRkZGTp8+nYUgPDycq9CAK8pZ6G3lypUUNmnSRP6J7naJkKd+9crVa/+5dpPjqjoqOa5evnr255t8tIAZJrZi5llSCW0wgA8++GDChAlspciCyJJ4lZaEeYSpVJ04cYISytEtz5qoCnFiJK6urpN1EHyylNPPyJEjCbjI2tvbYz8ib+m5tmHk+IzbJkKiUPz4/Pnz8ekIBjdFgq0aezCcGCW8YvQsQgSETAGnyLtb1UAbrtS8efOuXbuyD6Q3QAPEtAScxA85OTmIELnm5eWxhiEzailhSeNyuL7t27eT4CyeDe0Jg5l3to48pNsiwnPn2JReWLtx3eK0pUsyli5Znmx8ZPC6dPGqJRVH5lJ1GB6LVizJ3rLhlwvGX0ZuCFVEocQyGACRFM+rU6dOPXr0YD1FXWSJs/Bd2BVPH2PDCLEuHj3tUWNycjK2gdJ43HiekJAQ4iA03LFjx48++mjQoEF9+/bFaPv06dOhQwdKWPHpDfVqz7uW4dbYSW3duvX2iBDTBFYsXrF7jF4SdMruE0QJXBLp057rySxXA7N2RfcRZKJN6UG6kp5xrWibx0OWBJemhDaUSIJL60+hkOeRkJAgl6bP2yLCy5evhM0Pc412WLA6MnZVqOmRkBXtHGVv5do3LS8hKSc6MSdaXi143CEDSMqZvXhj7Ix5DjGpMfhDbUJNQIQ4MR4lDwsRsvg+99xzPAiiOHaGWCFG5eDgQGSUkpLCIw4ICGBjwt6PjcnChQtZjonFKKQx0iKNzD799FOUzCvNduzYQRWnt23blkK8IqfXVxFyMzeFCzAvLFq0lyk2BxwmASTThAOs2EHXHNlze3l54TnlT5S3RYRMWWlpub2/zY7zy3LPLsj7OUF/bL6QkHe2IrHt0qKkbWH+S91OXss/dG3l4WuZdXx8fy2z6NrqwmurDl0vIf39tVX6BhY8vr+28tvLq91iXKpZlPWekJ0FIsTsvvzyy86dOxM04gnJYlT4rvz8fPY+8rcKHjRmhn/DZkiw2WPbIp4QEQ4bNuyTTz5Bb7g+NizsiaZMmeLh4UH2s88+GzFiRD0WoTic6mHRYlIIFWokQgRz7Ngxpoa9H7u+3wYbVNZONugS+dwWEZ4/d76kuHxS0PCZ+zvZ72rpsLuN07620/a2nbqzzYTs96bsaEPJtH2tJy/vMmXBkIzL4xacHpBwxiq2uP/84wMTTlvVxXHGKv7UQL+C7lw08adBpJf8MiS6qNeCU/2TzpI1aV8nR8yx/vEnK2ZgwZl+GRfsPhn+vpenz5UrV5lPmVgjME3ZEwL7KOLPjz/+mG0FouKJyHtveDOcJDaGXRJ/Yta0JA5CY6WlpcRNPGv2h0FBQYSjiBC94QkRIV2NHj3azc2NGJVCJIqlnTp1iqvUAWxcb6cIMfGbQsjOtphLsiuT+TUH5hrN4MEY6G+GK7LJ1O89bpcIy0tOjvLrM6LguT6b/tY359HOyQ/1WvdI17SHXhn+p56rH+mf/2j/LQ8NXPKW9byuc89/GlDWOuh4G6/D7/n92CaovG1gmcFR3jagpI1PYSvj8rK2Qcfb+hxp5V/chjbGVeVtOSXAtKq8Le05K+Lc+2OSXx8c29BqzithZ9pzeB5q/mKLhz4Y93TEuXaG1yLtf6ziFC6nL9RXVVylpKoBvFdRZVLu92PrWVX05nXovYDi1qT9y1vOOdl10Iyer7zUUL6Y4/L5a5fOXzt/9oaPFuvfHWUtlj9RUIj3KykpwY55KNgiCXRIA7KUk6aErD7B6UgLEQ4ZMgThocAPP/wQcRLK4j+xzFatWlGIRAm76lKEixYtum0iXGAGhBDsm3+5A35B8jaKcJhvj2Gbn+u36dE+655o7/e3dx3vH7L9qTZeD3ZPf3xg7pMDNz/Wb+EbY2I/n/tzp4DidkGl7b2+bT3zm1ZeB1uT+PU42Npjf6sZu1p6G5V/29r7u9aUe+wzOYWqg1VU0du+it78fmjbw/slEl1nvFjR/nCr55s/sDFzm91YlzZjH6oYjP7Eg61n6k7hclrJ9UO7yv4qB+BJlUk59+i2u5Le6MR9b6uAY+0Ci9sHlLQOPNIxZIXnNzsPPfD076O/GZR22HP70RWlp45ePHf1l3Os1L++YSMqwmoRIdIi+ORV5x3NhdiPuHTw4MF4QnTYokWLCRMmiLfs27cvmkSESDQqKoqW2jm1DGvK7RQhnsocrhj8cp0FuV0iPF56apBPZ6ucp/vlPfxRxIPNpt7XdFIDqy2PtXT9a9fUh/tueLTfpod7xDccNufDyFMdZ/3QyveH1hyziio/fE1K5KiqnKP6quDytlazXx2R+PqAyIYVDrO0TfdZz/fu1r/T1x2sM18LLG1reopRiRy/bQBVHZyizcPRln5HOrgl2bk4zmzc/IXkIw4R/+7nXfCpf8HXqft8DpftQYe/nKuwToQnf2wgLCKL/PCEv02EgwYNIvLs06cPQZn8QYvd4/jx4ylEnEi0HouwwirrD7dPhKf7e37WJ/vRnlkPdk3724eR938S+0Dv7Ic+T3rw65V/67nuod4bHuwy719W0a3DjnfwKmzhXdiyLo9ZP7znvr/56KWNXP/97qyj73kfaRl6pm0XvyfHLH8l5FRbr++N29fx4XWkeVjZJ2/1evHVVxrt3fPNtavXzv587seT3+UdWTJ3x/iAvD4Ze4OPln938fyVC+cqfrcUBZ4+fRpLJR0XF0eQWfG5qpvBIyPwI4EXDQgIsLKy6tChw8CBA729vdEkW7IlS5Y4OTm9//77iBCJIkJayrm1TXl5+ULdV+zdHhESuNcj2CJyq7dBhCVneri377n+gW6r7+u+7v5eGx7omf3A16vv77H+/u5r769IZP+1U8xTfSPfCS5r4/n9O57fv1unx+F3vYve9S1p4V3UnLQUBhxv6VvcwuNwnQ/G9Chs5lXYfPCsLqdPVPxLBE4OEV44d4md4dmfz+46mjVvm33EpjFZ+xKKjxddOH/x4oXLF85XfJldfHy8s7MzFqzZcmUgPB5uhbvRfYaZVxHhgAEDOnbsiA579uyZkJCAJr28vMLCwtq0aUOMSjYyMrK+ilC3z6w38HjYlB88ePBWRMh6fOn8lQEuXVvO/t2nyX/8ZEklx2dpf2zu/+ePvP7h9l3Tqbtes/yx0yRhucPx340GZz5tGz4aHyhTqufs2XOXzv/np59/2l64JmGLa9wm5zW74/cd2Xb2wmkfH58nn3zSxcWFoFGzZRN4TFjzzp078ZYeHh4REREEfkjL398fEX700UdIjl3l1atXWYj37t3r6OjYrl07REhtPRbhvnoFt7p//37UqN2N2RiKEC5evLjnm3+P8x4+zn/gOP9Bpsf4wEHDPPsN9eo3JWaU3ewR6rjhiB5uFz7+wKGDVb1Xd+7s+Uvnr54+c3JvUX7mzrjkzWELs0KfeOrR/LzNKSkpLKCaLZuAdRYUFOAts7KyVq1aFR4erhdh//79ESGRJ6/y6WX2h1988QUKrPciJF/v0G6lJhiJkF0K9/7L2UtHvy8+dqTU9PixsKTsx+PHS08e/b7kaKE6bjh+OFx88VzFF/6eOXNGm9DKQIoXz18+f+7CiTNlh37Y99wLz7GLS05ORoTYqyli36Ghofb29klJSbm5ucHBwYgQ/Pz8+vbti/zQG84QcZaWltIPjVu1akWYikTFbWp91TJlZWW3U4Ra8X87RiJkb7lhwwYCpDlz5lZ6xMbGeXv7ODk5M9fsQBSGsLULCQnRm+DNOIsasbSkxKRHHnkEgRGOiimbwmNKTU2Njo7Oy8tj34EzxF4NRSifHc3MzExLS0OltGzZsiWF/fr1UyK80zEUIXvC06dPs60/dKiopORUcfEJ/VFSclISJ06czcnJZz1minQfSq/4RgNJ1BlGV6z7ARihHwBzUlxcjAAokSk1B87Kycnx9PTkXDHlSsFAaSCPDF93+PBhESHBp3jCDz74YOLEiePHj8/Ozra1tZU9IRKtSxHih7ENJcKaYShCpqy4+Ji/f2Bu7q41a/LWrs3PytqSlbV51apNK1Zkr19fsHZtXnb2tqSklHnz5tG4RPd9HxjEsWPHSJA1hBLTQuE3VOnLWQYYM3sPKWfpPaX78RbJGqI/xZTqq7TUjVR1CoVMI/KQNMNzcXHZtm0bJiSzelOYScLXmJgYtvRIy3yYBF9f3169en344Yc4PV4/++yzSZMmoUAcoPxrRe/evYlRaamdU8swCUqENcZIhGVlpR4e3gsWpEdHL549e3FIyLzY2FQfn8jRo+2cnWfNm5cWE5MSFDRHPt5x8ODBQ4cO7dL9NwkPgLQh1O7T/fOxEbSkvZxrCqdUWkUhZyF4IjGW/8TERNlB8dQxuMDAQGK573TfPKJHTjEdGFR1FaDKqB/h22+/pcq0N0p27tx54MABOgSmZciQIY8//vjy5cuxIlzilStXfvmlun9ukuUM/8njoDfzERH27NkT+eEM27Ztm5WVxePYuHEjfrV169aIEInWsQh5NEqENcNUhO7unvPmLUOE0dELra0dRoyYsHjxGnv7GWPH2s+fnx4Tk+zvH4XFMF9iecw46P/HSiCLN9i0aZNRObClYdNiegpQwimcaNob7eV7Rtzd3desWePo6EghD3jgwIHOzs7oEHNEJ9oJBqdwOa3oOvqraHkDpGr79u1a/jqUFxQUVNVbfn4++mRswJCWLVuGN3j66acxxxUrVjAM5vmC7jeb2HIzyTLbenTTXjZ79mw8oaZs8+CsWbNm9ejRA6eHCFEd1yVIcXNzGzFiRPv27SlEomFhYbTUzqllWIOUCGuMkQjLy8tcXNznzFnCMW2al5XV6O7dB0ydOnPAgBEREYmRkUmI08cnlG0GJ+7du5cpxi7FarX/7zKg0nJKKJeElOjRVxkhLanCs82cOTM1NXXGjBlclwF8/vnnoaGhgwcPRpasCPo+9aeYfxWoqqqa3gSZCvm3z7S0tHXr1jVo0GDMmDFWVlb4ItYIOzu7BQsWoFUmWdR4XvcfMD/99BPeEk+FVHgcmi1XDd6GmScKIC0i7N69OyLEGcoXjuEGmR8nJyeyiBCJKhHe6ZiK0Nl5BmKLiEgi/hw6dDwOcNiwCdbWjl5exDUJlM+cGYjdM+PIAPZUDT1rqRupqhyqr0KEmZmZ/v7+GRkZuB3xP2yEUCD3orUz4PYOoBpkKgBvPHLkyMcee4w9Hkpjt0yH+EPUMmjQIAQzceJE1MgpbGWxVCwNM23SpMnYsWORIpFwVTDhuEoSixYtWrp0KVm2oD4+Pl9//XWHDh1EhOvXr0eBISEh1tbWRKcUckUeFi2lk9qG+01ISFAirBmmInRwmB4auiAgIJbXkJAFYWHxJAIDYwMDY4KC4kJD411dfYOCgrA2zQvULYwWW+dVsqRRJmqUrGXBT6Ku8ePHozpMCF9HFIoU5e1TNJaTk8OGFr+NgyJidHV1ZXfduHHjyZMno0zRWKUUFhZi2YSsW7Zs4ZERgXMtOkSE3bp1ExG+//77xOqLFy9OTk62tbVFkxQiUSXCOx1DEeqiozOTJk2eNWt2cPCC4OD5pkdYWKKTk09AQABxkc4HWB7Gr6UsDeEoMsMRYT+m78QgSPlLBuLZvHkzqvP09Bw1atS9996L7eLcmFLdmzuVQFVKSgpaJdhj4xcbG8uDKykp8fb27tq1K/IjIm3VqpWNjQ0bVxQ4fPjwNm3aUIhEGQ8ttY5qGVSkRFhjDEUIV65cSU9PHzXK2t7eudJj6lSX0aOtecws4ZGKG4mKivLw8MjOzsb7aRNaGXhI5hkb4xUn2bdv35YtWwYHB7PT02z5RsTJ+Pr64jlxpMTe8h4V/s3Ly6tz586IEGfYrl27NWvWLF++HLki1GbNmiHCLl261LEI4+PjlQhrhpEIgXvfurVg2bKUjIx00yM9PW3lyhU8bFJszBR6mBD2Y0SJTKD8l6A5yKdMhwwZQhCLVAjyKwUR8pgKCgpwttu2bcORIkLaI8KvvvpKRIiSAwMDacljxSW2aNECESJR5F1cXKx1VMuwjigR1phKPWFgYNCSJUsXLVpieqSkpAYHh8yYMWPVqlUsugoj8IdZWVnVe0JDkOvFixfla/CJOTVbrgzURQN5PaT7uyXSQoRffvll+/btEWHbtm07duwYERERHh7evXt3shQi0ToWIWG2EmHNMNoTnjhxwtvb5+jRsuLik8eOnZCjpORkaenp4uKK9IkTZzdt2szunykCoimjRK1ieBVJ1/EATDG67unTp+fovvG6mr/OG4Gl4tNQL+rCv5kPO0l2lV988QUixBniCVesWLFlyxZWgZkzZzZv3hwRItGgoCBaaufUMljU/PnzlQhrhqEImTKWTF/fgKysLRkZ2StWbFy1KjczMzc5eVVSUlpmZs7y5RtWr85bsGDxvHnzWMJ5tLSXKSZdN7AR2rNnD0+LS/NaVsZ6UXz8+HFetRZ1DjOAB5A0I5k0aRK7MvN1qBch/k2zZfPgcmxBO3XqxG4QHb733nuZmZlOTk7dunVDmRSizM8//1yJ8E7HSITysbX589OiohZx+PpGR0UtDA6OGznSZurUmfPmpc2dmxwYOHvu3IovRGEjjt2wC9q/fz8JIiU9Ei/Rs1E5UMLGhgdWaRWncKJRFVnacxYPSb4PF2/D4AsLC3nAxGCOjo5Yv9Zah/6Uaq6i5Q2gilO4Ly1/nep727FjBzOge2Oi4p+qra2tn3jiCcJLrOiq7uPdkiDslD/Qy2zruXDhAuHo3Llz6Y2rVANX4VWCUtIiws8++wy9EXw2a9Zs4cKF3BqbRjzku+++iwiR6E1FSIfA4KX/apBHU02zoqIiwlG64pZZppUIzcJUhG5unnFxqdHRiyIjk8aOtRs0aHRc3LKhQ8chQhKI0N8/Mjo6GmsTy2PZIwTCELcbQLagoCAnJ8eoHBDtpk2bqDWtooRTTKukN87at28f29Hs7GwHBwfKcYmffPIJ5j506FB7e3tMRNoDpzAqTuFyWtF19FfR8gZIFXek5a9TfW95eXkMjNkAhJpBFJGd/cADDxATsl4wPBYOumWuiOaRIrIEtt+kgYS3t7etrS2PQzqpFE7HmkmsWbOGEZLFZLnEp59+2qZNG14HDBjAPNCPnZ1d3759W7dujXtEooGBgbREIShNlh4SkpU1Zd26dezwuRf6FzXSDOSKvMqJNEZR3BoJyulBuqJKRghYRVRU1LBhw8rLy9kYKxGahZEIr39sbfGcOUvt7d369RvWpUvviIhEa+upo0fbxsSkREcv9vau+NgaXgiDA5Swq67geWOvSUlJrPRcGtMfMmQI8uvduzemRq3Wrs6RqYDdu3cjOUKyJ598kkFOmzZtwoQJDLJPnz4MEuukBFkSN2L0GPGZM2eQzQsvvICceByaLZvArSG89evX87BWr15NY66FfyPBMtSyZcv+/fvjS1kcaZafn+/i4oInRISIU0RIJytXrmTJyM3NRXJMnXyPu/yyBSX4T7IMjB5oxvAoWb58Ob1xXS43a9YssrThHlloKGFVYheKASBIGSciTExMbNGiBUsA5sRag0rZQbD6EKqQYMy0EdszRYlQE6GTkyuqCw9PcHcPGjPGbuJEpxkzAiZMmObpGSYfW3N3l4+tfcfDwP54rTNkJQ4LC1u7di1mxMhZZQcPHozD4V7qeDBG6MS4C7+BHghHMWusSP5/ArdAOc4wPj4e2YwZM0a+hIKWvXr1atCgAbWLFy9GadxUpSBXlIBc09LSSKAxCjFZd3f3jz/+mFgUo2/VqhVhefPmzelzypQpKIEwFYkyOQgAfSYkJKDDkJCQmJgYlEkoGxwcjHRZLKjy8fFhq0+Hfn5+hLWsdP7+/uxvUSkLX3h4OCNnkJzIWdRiA5QQ69IzViTjJEFXXI7YmO0oPTMk+mFVQq5EH9wIUjx58iRzgiDFCPUoEWoinDrVWfextZiQkAWoLjw8MTh4XlhYPNnAwNjQ0HgXF4t9bI3lmXUXKfIqoSDxIRbMGixZi4MOCZWZUkyIKUWBzCpbQcJOtoUUEqTh/fAGeBLsG7eGG2RZwYFwI2LKlYISbGxsIiMjucT06dMxaIwYzbAlRmwosGHDhigKP4ZfcnJyQgaUU4sIcUT4MdYFPBgiTElJcXV1ZV+NYFAUfXJ1OheNoRlCSl5RKSXoB0kjUcIfnDzbAS8vr6ysLEqQK76Rng1FuGjRIgqff/75qVOnculx48bh//v169dNBwmWEiRNDIwgkStj06tRiVAs5qytrb2bW7C/f4yf31zTIyho3pQp7jwA7J5wRWEIKwKGjlmLAqsCWeIhL126JJ+bwRz//ve/Y6wok/WlUpjt9PT0uLg4RIsScGiU8Pjc3Nw++ugjvF/Pnj0xfapQO9EBEeY777yDh6QWOWHliBY5EVsuW7YMnWzevJloYuPGjVwdNmzYgK4ol9AUldKYaxFwEnqgba6IB8ab8UpLfCY90IAOeWVFlnEyJBo/8sgjaJVbIxxlZWE8NGCVJNalloCcQKBz585sXHHp9EkDfCMeUomwAtZp5t3e3tHFZWalx4wZnnZ2Ds7Ozswm66XCCCwefyhv0JvDT7pv1sJ34ejwDGLKlUItxopNg7Tk8ckPv7An/Oqrr3BieB58I12NHDmScBQRfvjhhwypqKiIS8gbm5xLgizCkFegT4IL/B46pA0N5B0aacB1OUuayav0IA14xavLIDEndrysF9yURAHiHlkF0Bh+TwJROsfMaDl27FhGjiaJrVAptUqEFc6Qe8/Pz0tNTU5PX5aenmZ0pKUtW748g3WRFHOtMAQHQjTIBGqzaR5YKiEZAsagsWbzQVo4nA4dOrRp0+a999573QBiURQon+EmaKSldk7ViIpQFK9aUc1BXbhrLEo+M8St0Rsa1qztOmgSKSI5EsTkKBCviG8U/3m3i5C5S0iIDwuLWL58ZXr6CtMjM3NNeHgkk5Wbm0ugojCEoC4mJoblSUzQTLBUvATbpN8mwvfff58NoWz/8HvEn7y2b9++devWiBCJminC2wIijI2NJTI384/1ROBlZWWoEdfKvpTd490uQqasvLzM19f32LHjRUVlRUWlchw5UnL06PGjR8uPHCktKTm1cWMecQtTxJYGKv455+pVSRtR03K4aRWvXFp/dSAtf3YzpTYGYArlUsUwmEN0yJBIyKzeFFpihZGRkcSBPAvz4dm5urqit7fffrtfv35EjJSgNyybh9i0aVP5UyFpecp1AFri9s0XoZ7i4mImQe0JK6aspKR41iy/lStzkpPXpKauzcjYkJa2niMpKT0xMX3ZsnXp6dkxMUmEHKdOneJ0Zo1nX1hYWOkffyothKrKofoqYePGjTxsIhkMjqgGB0IhWa2dAZRrqRupqhxqWkUhIRwjkTTbnuHDh7MNQ5AXLlw4f/48swrE+YJMtR7ZE2KmPj4+3IiYclXgati5sctizkmICPGBxKKI7YsvvmCj1b9//1mzZrHdatKkCSKktl6IUECKSoQVn5iZOdPr+sfWFnp4hAYHx8XHr/jkk862ti7z56frPrYWPWfOHIyePTrWsGPHDjELbFEPWdb13bt3G5UDzwkDkncItKLrUMIpplXSG2ehefmCXWDkQPt333131KhRjMfwLP0pXE4ruo7+KlreAKmSNxsMoZx7rKo3ZoDemA1gSE5OTi+88ML06dMJSlmq5NNboH9HFH3qwdJYU5599tnRo0dzLpeoil27dvGkuGJOTo67u7u84eHi4iIbQmjUqNG8efOIirH7gICAxo0bE6ayM0STrJJaL7UMs3ErIlSeUBOhm5tHXFxKdPSisLD40aNtBw4caW8/48svu0+Z4j5v3rK5c5f6+UVGR0ex6ovlbd26dfPmzdt1H7AwZMuWLZiLaTkllFNbTZWWvw7l0htDxexIODg4cN2dO3eiwOXLl48dOxb/w2C0E3SnMKrqB6DlDaAKSRQUFGj560hv+BnT3sDwY2uMMCMjA3O85557WBqQFmMbP368jY2No6Ojm5ubt+4HzAg+o6Oj0UxSUhKKpWSB7mugxJRNoYqB4S0ZeXBw8MiRI7kWzw6p4+5QIHpjKuzs7PB7EydObNasmRQiUSXCOx0jEcrH1mbPrvjYmq3t9F69BnXu3Mve3q1378EjRkyMiUnBQ3p5hUREhBcWfs+JgvYEah/8AGv83LlzMTWsENVNmzatT58+3bp1S0hIIKu1q3O0idB9/w26wlM1bNiQnTOjio2NJTgMDw8nRvX09EQ2U6ZMQZMTJkywtrYeOnRogwYNDh8+zFlyuinSP/1w4uTJk+kcmWHoxMD0htJa6njzzTdZJogRiEi7d++OJkWHSBcZaH3VMjwgno4SYc0wFaGTk2t4eGJo6AJv74hJk5zt7d0JQb28wj09w8LCKj5A4+4ewJNmzav4mFbdwlDz8/NZa3EIbJB46owfHeJGWOxxjFo7y4EV9ujRA+dGGivSx5y8EogSoGKdxKVMNRN+5swZskjx5ZdfRlqcK6ZshOjcz8+PQBfniaP28vLiZrllZ2dnlCYifOeddxAAM4PPRJxNmzalCpQI73RMRThlilNoaHxAQGxIyPyIiCRUFxhIuuKb1ww/tsZ0Ywd1DLsvnjQ+EKMkLciGjYTWyNLMnDmzrKwME2I3KBOrR3tzRgezDQgSZbq6uhKyVrOucb+8Ij8elsA8YNzIskWLFnoRduzYkZIZM2b069dPIlJqCYDxtNJPbUMwMmfOHCXCmmEoQizjwoULU6Y4TJ3q6eMThSc0PXx959jYTMfOmPFcxY2wb0xOTg4NDcXvyZSaA3N+8eLFiIgIUVpVoDp9A9K8Ii0k17x5cxSI2AhHU1NTi4uLDxw4wCazUaNGiJDaOhYhsbcSYc0wFCFgDazHTk7TJ060tbGZbGNjZ3qMHz/R3t6eiAgpKgwhpCRGYKuGf9Mm1Ayw1NLSUiJ8HoRmy+YhnpC9n4iQRGRkJAOgHxaC1157DRFSyJNSIryjMRIhc8cqGxoaQlBBcG9KXFysv78/1hYfHz9fYQD70ri4OEwQR8Rapk2oGdyKCNkPE4WiQCDBVnDs2LE8nY8//pisxKhKhHc6RuEo2xie2TffHCwuPvHjj+VyHDvGcZxX0seP/7RhQ25CQjxTxESDvNlQlxhdse4HYIR+AFevXi0sLIyKiiIhU3pTmHD5+2F4eDjLn7atrBY2wDwyEkgLEbL3Q4GEnW+//fYs3f/dEhKPHj26adOmiJBaHugh3beQ1AEsQNHR0UqENcPojZni4mMBAYEFBXvXry/Izi7YsGFbdvbWjRu3rVmTm5W1ecOGrbm5OxcvXsbCf/78+bKyMvnXzBLd7wSaQq2WupGqyqH6KjzGqVOnuNzJkyf1hYz8zJkzVEmJIbd9AFrqRpgBuToNGJinpychPSYks2qI7h0Z7T8Mgd0gxkp23Lhxo0aNqv69LjaE+3Wff0hJSVmxYgVuBxE6OjqiPfGEJKZMmbJ69WpU6ubm9vrrryNCChmPEuEdjZEI5Yue4uMzZs+u+GGmiIjEhIQVDg4eEyZMi4xMiolJiY1NDQ6uiFRRAqYmcQ5TT4InrYcstRiNUTlQQnsMrtIqTpFutSIdZGnPWUePHl2/fn1gYCCLPWmeLnZPAMZ4sH5O1E4wOKWaq2h5A6qqqr43CcM4C5iWAQMGPP300zk5OViR7lOl2idOcZjyxwm8H0uJrCOkraysCBq9vb25tGbLJqC9jbqfW1q3bp2trW1eXh6a5NKI8M0338QNAglCYlqyLfziiy9EnBQqEd7pmIpQfp9w9uzF0dGLJk6cZmPjPHmyy5gxkxEkskSH/v5Rs2f/+vuEzDhgEzx+PWS3b9+em5trVA5cDhui1rSKEk4xrZLeOIvLeXh4rFy5kjCMQqx2/PjxY8aM6dmzJ0EgStBO0J3CqDiFy2lF19FfRcsbIFU7dH8IMYTyrVu3VtobbN68GefDbAAJFoiIiIhnnnkGcyTBkkGUiMZcXV3RzOTJk62trUeMGDF06NBhw4b16dNHfosiISEBI9b9zaUSGEBGRgYnstwsWbIkICCAiyJCBwcHwk4RIapDzwgV2UdGRjZs2BARUsuMsTpoHdUyPBEeBDOvRFgDjERIwOXqOpMHjSecPt138OCxXbr0Qnj29jMGDRoTF5eKOH18wiIjK36fkPkF/ACTrj2E62DigOFq+RuhnFotcyNSZVpLCVUSaLHtcXFx4bqYZvv27TFfbHrChAlIVGutQ07RMjdy0wFoGQMoNL1NoBz2Xv9/PEaVnp6OQho0aIDegBCRJWP69OmIwc/Pj70fQkpMTFxMWL9s2apVq4gbaTBnzhz0rHV6I+JkuGVWHNk6ImZcIvtPRPjGG2+8qwMRov+YmBj5cQu8K8qkVonwTsdUhPL7hJGRCx0dPa2sRg8bZu3tHT5qlO20ad4U6n6fMCgs7IbfJ6SHugFfh4n7+vqyLxLPw9XbtWuHAouKirRGlkCmAhgSg3nqqadwVlgRU8reT956kaAUNyWfoQFJoFu8Fo6RuxNJm4IIWXqINtEenpBYgGshralTpzZp0gQFIjmcHgrs1KnTs88+q49RGzduPHPmTJYnraNahlUSJ6xEWDNMRejoOD00NF734ZgFuh8krPjSJ46wsITrv0/oFxQU/O23N7idOoPR8rB51WdBXJCUWBCkgkvELc+fPx8TYj5B3owBmWQj2BPSslT3c5/cgpiyKZg1y43cJgmgUESII0WBzZo1I5GVlcXiyO6R0Pe1115DnBTWpQgZoRJhjTEUIYZy5szpSZPsdJ9Zq/h6NSSnP+STaxERCwlT2foTC4kA6h4MXUvp4DEblVgKRkIgGhoaiv1UpTpTsNTjx48HBwcjY8zXfJAWsW6jRo0QIRCOdu7cmTBB/k741ltvIUJqyeJjtXNqGR4E22ASSoQ1wFCEQLy0aNGioUPH2No62dpOs7ExPuzsnIcNG0PEFRsbS/SvMGT27Nm4nczMTKZRm1AzwFLxhIGBgb9BhPb29ng88YSvvvoq2z9xyAMGDBAPSa0S4Z2OkQiBe9+6tSA1NcXoK570h/73CRVGpKamogEmkCBTm00zwFJpHxISgu1uNQOdtVe0RFqIEO2JG2RPiB9u1aoVheyZX3jhBcrZbbq5ubFTlXNrG2wpPDyc4SkR1gAjEV6+fHnt2rUBAQGJiUkJCYmmx6JFiwMDg3iuYnMKQzB9/EBeXp6YoJlgbFits7Mz+z3NlitDJ70K0HmO7gczRITIDLG98cYbzz77LFdHh5QTpr7yyiuU86pEeKdjtCc8deqUt7d3YeGxkpJTxcUn9Edp6amSkpMkTp6s+H3CRYsWMkX/0aFP1Blc0fCiRtm6R391EuXl5QSlJGRKTWGSz+u+kFveKaVlcnLy448/PmrUKOy1oAqw79zcXOSNArHypKQkChGbnZ3dyy+/3KRJE3aDI3Q4OjpaWVlRSIAKJGbMmLF//37pp7bZs2dPWFjY9u3blQhrgKEImbLi4mI/v4CNG7dnZm5avTp37dp8Xtet27xs2dqMjPWrV+dlZW1JSFg6b9482tO4pKSkqKiIuSNB1ohKC6GqcrhpFVbOXohNlGTLysrkK2V1TYy5jQOgvNIqCpnDY7qfaiR94sQJBweHDRs2YELoTSQn/zQoQiVNm++++27Lli2rV69esmTJP//5T/bhcXFxmiFXBtpbtWqVq6trUFCQjY0NuuV0/NvkyZNfeumlRo0a9erVSz46R4fx8fG0IUxFhC+++KIS4Z2OkQjlY2sLFqRFRVV8YiYwMCY2NsXdPcja2iE0dMHcuUtjYlJ0v084F5tDDPJ5KJ7xYd3n1PRQTi0PgIRWdB1a7tu3j1XctIoSTpFutSIdZGnPWTykjIwMf90PjBw9erSwsJCSrl27enp6ysfW9OhPMRoY6K+i5Q2oqqqa3ihhBtADZwFqHDlyJJ4NXWFFTCkDY553796dmZlJuIinkg/K9O7de5CO++67j1ruiEgSaZmCceMJkZ+tre24cePYLLi7u+MMubT8ohMbwtdff33MmDFZWVnBwcF+fn44Q5RJObVIl5FrfdUy3EhoaKgSYc0wFaHuY2up0dGLo6IWjh8/ZcwYu/79R4wda+ftHRETk8zh7x8VHf3rx9awD6wEQ2S11kOWcrYuRuXAzmfTpk3UmlZRIrudSnvjLNTODmfdunWYMoWMvHv37j4+PgMHDqQcnehPJMGoOIXLSYkequQqWt4AqZJ9lyGUY2EEhJX2lp+fj5UzG7B37175bvKHH354+vTpkyZNQpPy60v9+vUbP3480X5iYuLGjRu5F+YQx4ii/v73v+PTcCNiyqYw2sDAQBcXF2IQVkCUhrPlfhHh888/j9jeeustIs/XXnsN10cJCQrhueeeUyK80zESYbn2+4RL5sxZ6uDgMWDAiB49BvbvP9zGxrlfv+F4Qv3vE3IiBscUM+9ii6bUtByqr8LKcXpLly7FcBk2V0eEmLWIkBVBa3qd2z4ALWUCUyGg0tTUVHT4yCOPIJuoqChcFmEn5xK3M8lsBbEudoOYKQq8cOEC2ZiYGPRJP5ot34h4SJYGlhX6EccISAuRIzMU+KaOpk2bSkKg/F//+hdrQV2KMCQkRImwZpiK0Nl5RkREIoeLi9/w4RPGjZvi4REyapSNi4tvRESS7mNr8vuE2sfWoOITHHUCxrR27VqMW36WiAdMQNitWzcUSHRalyMxQuYBWAiGDBny6KOPSjgq+0DQ/wuFTLUh8j9NRJuIrXqwci2lgxmwt7d/4oknEBvyM4VyavGETJR2Ti3DGiR/a1EirAGmInRw0H6fkNewsPiwsAQSukM+y2b53ydkwCAlPHVGgjlK1uIwPBsbG2JaTEhm9aacPXv29OnTM2fOJNzFGWodmQGTwJLUunVrtn/sCU2hvF27dmwUGZV2Ti1DLODl5cVDUSKsAYYixBp+/vknGxs7L6/IoKB5gYFxpgcidHT0YuuPC2Ku7wTwP1rK0mDr2dnZuALzFSgQo2ZmZhI3+vv7M7dm4uvry7WIxtkZ6v5hoxLYMLOBpKV2Ti3DUkIEjvZ0tqREaB6GIoQrVy6zgRk5ctzEifaVHjY2U4cNG21tbU1EGqC4EeJkAuO8vDyCT21CzQbXweNg01vxHmtNOHz4MA+xKqjV2tU+hCQszYTWaE9uSonQLHhOhiIEDIigtKjoyA8/FFV6/Pgj+6+KPw/IY1bowdrKysqYwBp9bE0P5su+sb4jPlBQIjQLTMdIhCBvFSh+A3onoAAlQrMQEbJ6KRS3HVZzJcKbgwh37959RqGoBXCGLPFKhDdH9/etiu9fUihuL3t039tfpPsFVXO4e0V4tOrfplUobpEaWdfdK0KF4g5BiVChsDBKhAqFhVEiVCgsjBKhQmFhlAgVCgujRKhQWBglQoXCwigRKhQWRolQobAwSoQKhYVRIlQoLIwSoUJhYZQIFQoLo0SoUFgYJUKFwsIoESoUFkaJUKGwMEqECoWFUSJUKCyMEqFCYWGUCBUKC6NEqFBYGCVChcLCKBEqFBZGiVChsDBKhAqFhVEiVCgsjBKhQmFhlAgVCgujRKhQWBglQoXCwigRKhQWxliECoXCImgiVCgUFuN3v/t/WRyGCq1sKO0AAAAASUVORK5CYII=</bitmap>
         </item>
       </items>
     </chunk>

--- a/docs/examples/02_description_models/files/02_robot_artist_rhino.py
+++ b/docs/examples/02_description_models/files/02_robot_artist_rhino.py
@@ -2,7 +2,7 @@ import compas
 compas.PRECISION = '12f'
 
 from compas.robots import *
-from compas_fab.rhino import RobotArtist
+from compas_fab.rhino import RobotModelArtist
 
 r = 'ros-industrial/abb'
 p = 'abb_irb6600_support'
@@ -14,4 +14,4 @@ urdf = github.load_urdf('irb6640.urdf')
 robot = RobotModel.from_urdf_file(urdf)
 robot.load_geometry(github)
 
-RobotArtist(robot).draw_visual()
+RobotModelArtist(robot).draw_visual()

--- a/docs/examples/02_description_models/files/02_robot_artist_rhino_from_ros.py
+++ b/docs/examples/02_description_models/files/02_robot_artist_rhino_from_ros.py
@@ -1,6 +1,6 @@
 import compas
 from compas_fab.backends import RosClient
-from compas_fab.rhino import RobotArtist
+from compas_fab.rhino import RobotModelArtist
 
 # Set high precision to import meshes defined in meters
 compas.PRECISION = '12f'
@@ -10,6 +10,6 @@ with RosClient() as ros:
     robot = ros.load_robot(load_geometry=True)
 
     # Visualize robot
-    robot.artist = RobotArtist(robot.model, layer='COMPAS FAB::Example')
+    robot.artist = RobotModelArtist(robot.model, layer='COMPAS FAB::Example')
     robot.artist.clear_layer()
     robot.artist.draw_visual()

--- a/docs/examples/03_backends_ros/files/robot-playground.ghx
+++ b/docs/examples/03_backends_ros/files/robot-playground.ghx
@@ -3238,7 +3238,7 @@ from scriptcontext import sticky as st
 
 import compas
 from compas_fab.robots.ur5 import Robot
-from compas_fab.ghpython import RobotArtist
+from compas_fab.ghpython import RobotModelArtist
 
 compas.PRECISION = '12f'
 
@@ -3251,7 +3251,7 @@ if robot_key not in st:
 
 if load:
     robot = Robot(load_geometry=True)
-    robot.artist = RobotArtist(robot.model)
+    robot.artist = RobotModelArtist(robot.model)
     st[robot_key] = robot
     robot.scale(scale_factor)
 
@@ -12922,7 +12922,7 @@ from compas_fab.backends import RosClient
 from compas_fab.backends import RosFileServerLoader
 from compas_fab.robots import Robot
 from compas_fab.robots import RobotSemantics
-from compas_fab.ghpython import RobotArtist
+from compas_fab.ghpython import RobotModelArtist
 
 # Set high precision to import meshes defined in meters
 compas.PRECISION = '24f'
@@ -12947,7 +12947,7 @@ if client and client.is_connected and load:
     semantics = RobotSemantics.from_srdf_string(srdf, model)
 
     robot = Robot(model, semantics=semantics)
-    robot.artist = RobotArtist(robot.model)
+    robot.artist = RobotModelArtist(robot.model)
     robot.scale(scale_factor)
     st[robot_key] = robot
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 requirements = [
     # Until COMPAS reaches 1.0, we pin major.minor and allow patch version updates
-    'compas>=0.16.1,<0.17',
+    'compas>=0.16.2,<0.17',
     'roslibpy>=1.1.0',
     'pybullet',
     'pyserial',

--- a/src/compas_fab/artists/__init__.py
+++ b/src/compas_fab/artists/__init__.py
@@ -17,15 +17,15 @@ of the CAD environment.
     :toctree: generated/
     :nosignatures:
 
-    BaseRobotArtist
+    BaseRobotModelArtist
 
 
 """
 
 from __future__ import absolute_import
 
-from compas_fab.artists.base import BaseRobotArtist
+from compas_fab.artists.base import BaseRobotModelArtist
 
 __all__ = [
-    'BaseRobotArtist'
+    'BaseRobotModelArtist'
 ]

--- a/src/compas_fab/blender/__init__.py
+++ b/src/compas_fab/blender/__init__.py
@@ -20,10 +20,11 @@ in Blender.
     :toctree: generated/
     :nosignatures:
 
-    RobotArtist
+    RobotModelArtist
 
 """
 
 from .artists import RobotArtist
+from .artists import RobotModelArtist
 
-__all__ = ['RobotArtist']
+__all__ = ['RobotArtist', 'RobotModelArtist']

--- a/src/compas_fab/blender/artists.py
+++ b/src/compas_fab/blender/artists.py
@@ -58,6 +58,5 @@ class RobotModelArtist(BaseRobotModelArtist):
         bpy.ops.wm.redraw_timer(type='DRAW_WIN_SWAP', iterations=1)
 
 
-
 # deprecated alias
 RobotArtist = RobotModelArtist

--- a/src/compas_fab/blender/artists.py
+++ b/src/compas_fab/blender/artists.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 from compas_blender import draw_mesh
 
-from compas_fab.artists import BaseRobotArtist
+from compas_fab.artists import BaseRobotModelArtist
 
 try:
     import bpy
@@ -13,16 +13,24 @@ except ImportError:
     pass
 
 __all__ = [
-    'RobotArtist',
+    'RobotModelArtist',
 ]
 
 
-class RobotArtist(BaseRobotArtist):
-    """Visualizer for robots inside a Blender environment."""
+class RobotModelArtist(BaseRobotModelArtist):
+    """Visualizer for robot models inside a Blender environment.
 
-    def __init__(self, robot, layer=None):
+    Parameters
+    ----------
+    model : :class:`compas.robots.RobotModel`
+        Robot model.
+    layer : str, optional
+        The name of the layer that will contain the robot meshes.
+    """
+
+    def __init__(self, model, layer=None):
         self.layer = layer
-        super(RobotArtist, self).__init__(robot)
+        super(RobotModelArtist, self).__init__(model)
 
     def transform(self, native_mesh, transformation):
         native_mesh.matrix_world @= mathutils.Matrix(transformation.matrix)
@@ -48,3 +56,8 @@ class RobotArtist(BaseRobotArtist):
 
     def redraw(self, timeout=None):
         bpy.ops.wm.redraw_timer(type='DRAW_WIN_SWAP', iterations=1)
+
+
+
+# deprecated alias
+RobotArtist = RobotModelArtist

--- a/src/compas_fab/ghpython/__init__.py
+++ b/src/compas_fab/ghpython/__init__.py
@@ -20,12 +20,14 @@ in Grasshopper.
     :toctree: generated/
     :nosignatures:
 
-    RobotArtist
+    RobotModelArtist
 
 
 """
 
 from .artists import RobotArtist
+from .artists import RobotModelArtist
+
 from .path_planning import *          # noqa: F401,F403
 
-__all__ = ['RobotArtist']
+__all__ = ['RobotArtist', 'RobotModelArtist']

--- a/src/compas_fab/ghpython/artists.py
+++ b/src/compas_fab/ghpython/artists.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 from compas.utilities import rgb_to_rgb
 from compas_ghpython.utilities import draw_mesh
-from compas_rhino.geometry.transformations import xtransform
+from compas_ghpython.geometry import xtransform
 
 from compas_fab.artists import BaseRobotModelArtist
 

--- a/src/compas_fab/ghpython/artists.py
+++ b/src/compas_fab/ghpython/artists.py
@@ -3,35 +3,45 @@ from __future__ import division
 from __future__ import print_function
 
 from compas.utilities import rgb_to_rgb
+from compas_ghpython.utilities import draw_mesh
+from compas_rhino.geometry.transformations import xtransform
 
-from compas_ghpython import mesh_draw
-from compas_ghpython.geometry import xform_from_transformation
-
-from compas_fab.artists import BaseRobotArtist
+from compas_fab.artists import BaseRobotModelArtist
 
 __all__ = [
     'RobotArtist',
+    'RobotModelArtist',
 ]
 
 
-class RobotArtist(BaseRobotArtist):
-    """Visualizer for robots inside a Grasshopper environment."""
+class RobotModelArtist(BaseRobotModelArtist):
+    """Visualizer for robots inside a Grasshopper environment.
 
-    def __init__(self, robot):
-        super(RobotArtist, self).__init__(robot)
+    Parameters
+    ----------
+    model : :class:`compas.robots.RobotModel`
+        Robot model.
+    """
+
+    def __init__(self, model):
+        super(RobotModelArtist, self).__init__(model)
 
     def transform(self, native_mesh, transformation):
-        T = xform_from_transformation(transformation)
-        native_mesh.Transform(T)
+        xtransform(native_mesh, transformation)
 
     def draw_geometry(self, geometry, name=None, color=None):
         if color:
             color = rgb_to_rgb(color[0], color[1], color[2])
+        vertices, faces = geometry.to_vertices_and_faces()
 
-        mesh = mesh_draw(geometry, color=color)
+        mesh = draw_mesh(vertices, faces, color=color)
 
         # Try to fix invalid meshes
         if not mesh.IsValid:
             mesh.FillHoles()
 
         return mesh
+
+
+# deprecated alias
+RobotArtist = RobotModelArtist

--- a/src/compas_fab/ghpython/path_planning.py
+++ b/src/compas_fab/ghpython/path_planning.py
@@ -9,7 +9,7 @@ import compas
 from compas.datastructures import Mesh
 from compas.geometry import Transformation
 from compas_rhino.geometry import RhinoMesh
-from compas_rhino.geometry.transformations import xform_from_transformation
+from compas_ghpython.geometry import xform_from_transformation
 
 from compas_fab.robots import Configuration
 

--- a/src/compas_fab/ghpython/path_planning.py
+++ b/src/compas_fab/ghpython/path_planning.py
@@ -8,17 +8,15 @@ from timeit import default_timer as timer
 import compas
 from compas.datastructures import Mesh
 from compas.geometry import Transformation
-from compas_ghpython.geometry import xform_from_transformation
 from compas_rhino.geometry import RhinoMesh
+from compas_rhino.geometry.transformations import xform_from_transformation
 
 from compas_fab.robots import Configuration
 
-try:
+if compas.RHINO:
     import clr
     import rhinoscriptsyntax as rs
     import Rhino.Geometry as rg
-except ImportError:
-    compas.raise_if_ironpython()
 
 __all__ = [
     'PathVisualizer',

--- a/src/compas_fab/rhino/__init__.py
+++ b/src/compas_fab/rhino/__init__.py
@@ -13,17 +13,18 @@ datastructures and models, in a way that maintains the data separated from the
 specific CAD interfaces, while providing a way to leverage native performance
 of the CAD environment.
 
-This package provides a robot artists implementation that are optimized to use
+This package provides a robot model artist implementation optimized to use
 in Rhino.
 
 .. autosummary::
     :toctree: generated/
     :nosignatures:
 
-    RobotArtist
+    RobotModelArtist
 
 """
 
 from .artists import RobotArtist
+from .artists import RobotModelArtist
 
-__all__ = ['RobotArtist']
+__all__ = ['RobotArtist', 'RobotModelArtist']

--- a/src/compas_fab/rhino/artists.py
+++ b/src/compas_fab/rhino/artists.py
@@ -8,7 +8,6 @@ import compas
 import compas_rhino
 from compas.geometry import centroid_polygon
 from compas.utilities import pairwise
-from compas_rhino.geometry.transformations import xtransform
 
 from compas_fab.artists import BaseRobotModelArtist
 
@@ -42,7 +41,8 @@ class RobotModelArtist(BaseRobotModelArtist):
         self.layer = layer
 
     def transform(self, native_mesh, transformation):
-        xtransform(native_mesh, transformation)
+        T = xform_from_transformation(transformation)
+        native_mesh.Transform(T)
 
     def draw_geometry(self, geometry, name=None, color=None):
         # Imported colors take priority over a the parameter color
@@ -196,6 +196,20 @@ class RobotModelArtist(BaseRobotModelArtist):
 
             obj.CommitChanges()
 
+# TODO: switch to compas_rhino.geometry.transformations.xtransform
+# as soon as this is in the release
+def xform_from_transformation(transformation):
+    """Creates a Rhino Transform instance from a :class:`Transformation`.
+    Args:
+        transformation (:class:`Transformation`): the transformation.
+    Returns:
+        (:class:`Rhino.Geometry.Transform`)
+    """
+    transform = Rhino.Geometry.Transform(1.0)
+    for i in range(0, 4):
+        for j in range(0, 4):
+            transform[i, j] = transformation[i, j]
+    return transform
 
 # deprecated alias
 RobotArtist = RobotModelArtist

--- a/src/compas_fab/rhino/artists.py
+++ b/src/compas_fab/rhino/artists.py
@@ -196,6 +196,7 @@ class RobotModelArtist(BaseRobotModelArtist):
 
             obj.CommitChanges()
 
+
 # TODO: switch to compas_rhino.geometry.transformations.xtransform
 # as soon as this is in the release
 def xform_from_transformation(transformation):
@@ -210,6 +211,7 @@ def xform_from_transformation(transformation):
         for j in range(0, 4):
             transform[i, j] = transformation[i, j]
     return transform
+
 
 # deprecated alias
 RobotArtist = RobotModelArtist

--- a/src/compas_fab/rhino/artists.py
+++ b/src/compas_fab/rhino/artists.py
@@ -6,44 +6,43 @@ import time
 
 import compas
 import compas_rhino
-
-from compas_fab.artists import BaseRobotArtist
-from compas.utilities import pairwise
 from compas.geometry import centroid_polygon
+from compas.utilities import pairwise
+from compas_rhino.geometry.transformations import xtransform
 
-try:
+from compas_fab.artists import BaseRobotModelArtist
+
+if compas.RHINO:
     import Rhino.Geometry
     import scriptcontext as sc
     from System.Drawing import Color
     from Rhino.DocObjects.ObjectColorSource import ColorFromObject
     from Rhino.DocObjects.ObjectColorSource import ColorFromLayer
     from Rhino.DocObjects.ObjectMaterialSource import MaterialFromObject
-except ImportError:
-    compas.raise_if_ironpython()
 
 __all__ = [
     'RobotArtist',
+    'RobotModelArtist',
 ]
 
 
-class RobotArtist(BaseRobotArtist):
+class RobotModelArtist(BaseRobotModelArtist):
     """Visualizer for robots inside a Rhino environment.
 
     Parameters
     ----------
-    robot : compas.robots.RobotModel
+    model : :class:`compas.robots.RobotModel`
         Robot model.
     layer : str, optional
         The name of the layer that will contain the robot meshes.
     """
 
-    def __init__(self, robot, layer=None):
-        super(RobotArtist, self).__init__(robot)
+    def __init__(self, model, layer=None):
+        super(RobotModelArtist, self).__init__(model)
         self.layer = layer
 
     def transform(self, native_mesh, transformation):
-        T = xform_from_transformation(transformation)
-        native_mesh.Transform(T)
+        xtransform(native_mesh, transformation)
 
     def draw_geometry(self, geometry, name=None, color=None):
         # Imported colors take priority over a the parameter color
@@ -111,7 +110,7 @@ class RobotArtist(BaseRobotArtist):
         self.redraw()
 
     def draw_collision(self):
-        collisions = super(RobotArtist, self).draw_collision()
+        collisions = super(RobotModelArtist, self).draw_collision()
         collisions = list(collisions)
 
         self._enter_layer()
@@ -122,7 +121,7 @@ class RobotArtist(BaseRobotArtist):
         self._exit_layer()
 
     def draw_visual(self):
-        visuals = super(RobotArtist, self).draw_visual()
+        visuals = super(RobotModelArtist, self).draw_visual()
         visuals = list(visuals)
 
         self._enter_layer()
@@ -176,7 +175,7 @@ class RobotArtist(BaseRobotArtist):
                 attr.ObjectColor = Color.FromArgb(a, r, g, b)
                 attr.ColorSource = ColorFromObject
 
-                material_name = 'robotartist.{:.2f}_{:.2f}_{:.2f}_{:.2f}'.format(r, g, b, a)
+                material_name = 'robotmodelartist.{:.2f}_{:.2f}_{:.2f}_{:.2f}'.format(r, g, b, a)
                 material_index = sc.doc.Materials.Find(material_name, True)
 
                 # Material does not exist, create it
@@ -198,18 +197,5 @@ class RobotArtist(BaseRobotArtist):
             obj.CommitChanges()
 
 
-# TODO: Move to compas_rhino.geometry
-def xform_from_transformation(transformation):
-    """Creates a Rhino Transform instance from a :class:`Transformation`.
-
-    Args:
-        transformation (:class:`Transformation`): the transformation.
-
-    Returns:
-        (:class:`Rhino.Geometry.Transform`)
-    """
-    transform = Rhino.Geometry.Transform(1.0)
-    for i in range(0, 4):
-        for j in range(0, 4):
-            transform[i, j] = transformation[i, j]
-    return transform
+# deprecated alias
+RobotArtist = RobotModelArtist

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -35,8 +35,8 @@ class Robot(object):
     ----------
     model : :class:`RobotModel`
         The robot model, usually created from an URDF structure.
-    artist : :class:`compas_fab.artists.BaseRobotArtist`
-        Instance of the artist used to visualize the robot. Defaults to ``None``.
+    artist : :class:`compas_fab.artists.BaseRobotModelArtist`
+        Instance of the artist used to visualize the robot model. Defaults to ``None``.
     semantics : :class:`compas_fab.robots.RobotSemantics`
         The semantic model of the robot. Defaults to ``None``.
     client : :class:`compas_fab.backends.interfaces.ClientInterface`
@@ -59,7 +59,7 @@ class Robot(object):
 
     @property
     def artist(self):
-        """:class:`compas_fab.artists.BaseRobotArtist`: Artist used to visualize robot."""
+        """:class:`compas_fab.artists.BaseRobotModelArtist`: Artist used to visualize robot model."""
         return self._artist
 
     @artist.setter


### PR DESCRIPTION
First step before moving these artists up to `compas` core, they've been rename to `RobotModel` artists.
This is a breaking change, although a minor one. I created aliases to preserve the old names for a little longer, but the `self.robot` instance variable of artists has changed to `self.model` and there's no alias for it.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
