### PR TITLE
Configuration from group states

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Unreleased
 * Added ``compas_fab.robots.Configuration.merge``
 * Added ``compas_fab.robots.JointTrajectoryPoint.merge``
 * Added ``compas_fab.robots.Semantics.group_states``
+* Added ``compas_fab.robots.Robot.get_configuration_from_group_state``
 
 **Changed**
 

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -607,6 +607,27 @@ class Robot(object):
                 configuration.joint_names = joint_names
         return configuration, configuration.scaled(1. / self.scale_factor)
 
+    def get_configuration_from_group_state(self, group, group_state):
+        """Get a ``Configuration`` from a group's group state.
+
+        Parameters
+        ----------
+        group : :obj:`str`
+            The name of the planning group.
+        group_state : :obj:`str
+            The name of the ``group_state``.
+
+        Returns
+        -------
+        :class:`Configuration`
+            The configuration specified by the ``group_state``.
+        """
+        joint_dict = self.group_states[group][group_state]
+        group_joint_names = self.get_configurable_joint_names(group)
+        group_joint_types = self.get_configurable_joint_types(group)
+        values = [joint_dict[name] for name in group_joint_names]
+        return Configuration(values, group_joint_types, group_joint_names)
+
     # ==========================================================================
     # transformations, coordinate frames
     # ==========================================================================


### PR DESCRIPTION
Closes #223 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
