### PR TITLE
silly bugs

### DIFF
--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -76,7 +76,6 @@ class PyBulletInverseKinematics(InverseKinematics):
 
         called_from_test = 'pytest' in sys.modules
         if options.get('enforce_joint_limits', True) and not called_from_test:
-            
             lower_limits = [joint.limit.lower if joint.type != Joint.CONTINUOUS else 0 for joint in joints]
             upper_limits = [joint.limit.upper if joint.type != Joint.CONTINUOUS else 2 * math.pi for joint in joints]
             # I don't know what jointRanges needs to be.  Erwin Coumans knows, but he isn't telling.

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -62,11 +62,12 @@ class PyBulletInverseKinematics(InverseKinematics):
         ------
         :class:`compas_fab.backends.InverseKinematicsError`
         """
+        options = options or {}
         link_name = options.get('link_name') or robot.get_end_effector_link_name(group)
         link_id = self.client._get_link_id_by_name(link_name, robot)
         point, orientation = pose_from_frame(frame_WCF)
 
-        joints = robot.get_configurable_joints()
+        joints = robot.model.get_configurable_joints()
         joints.sort(key=lambda j: j.attr['pybullet']['id'])
         joint_names = [joint.name for joint in joints]
 
@@ -75,7 +76,7 @@ class PyBulletInverseKinematics(InverseKinematics):
 
         called_from_test = 'pytest' in sys.modules
         if options.get('enforce_joint_limits', True) and not called_from_test:
-
+            
             lower_limits = [joint.limit.lower if joint.type != Joint.CONTINUOUS else 0 for joint in joints]
             upper_limits = [joint.limit.upper if joint.type != Joint.CONTINUOUS else 2 * math.pi for joint in joints]
             # I don't know what jointRanges needs to be.  Erwin Coumans knows, but he isn't telling.


### PR DESCRIPTION
The pybullet id of a joint is written into the model's joint attrs not the semantics joint attrs.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
