### PR TITLE
Two fixes in one

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,8 @@ Unreleased
 **Fixed**
 
 * Fixed bug in ``add_attached_tool`` of ``PlanningScene``
-* Fixed frame_id generation when tool name changes
+* Fixed ``frame_id`` generation when tool name changes
+* Fixed freeze with some sync planning scene methods on Grasshopper/IronPython
 
 **Deprecated**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Unreleased
 **Fixed**
 
 * Fixed bug in ``add_attached_tool`` of ``PlanningScene``
+* Fixed frame_id generation when tool name changes
 
 **Deprecated**
 

--- a/src/compas_fab/backends/ros/service_description.py
+++ b/src/compas_fab/backends/ros/service_description.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 import types
 
+import compas
 from roslibpy import Service
 from roslibpy import ServiceRequest
 
@@ -32,13 +33,14 @@ class ServiceDescription(object):
 
     def call(self, client, request, callback, errback):
         def inner_handler(response_msg):
-            # IronPython sometimes decides it's a good idea to use an old-style class
-            # to pass the response_msg around, so we need to make sure we turn it into
-            # a proper ServiceResponse again
-            # https://github.com/compas-dev/compas_fab/issues/235
-            is_old_style_class = isinstance(response_msg, types.InstanceType)
-            if is_old_style_class:
-                response_msg = dict(response_msg)
+            if not compas.PY3:
+                # IronPython sometimes decides it's a good idea to use an old-style class
+                # to pass the response_msg around, so we need to make sure we turn it into
+                # a proper ServiceResponse again
+                # https://github.com/compas-dev/compas_fab/issues/235
+                is_old_style_class = isinstance(response_msg, types.InstanceType)
+                if is_old_style_class:
+                    response_msg = dict(response_msg)
             response_object = self.response_class.from_msg(response_msg)
 
             # Validate the response if there's a validator function assigned

--- a/src/compas_fab/backends/ros/service_description.py
+++ b/src/compas_fab/backends/ros/service_description.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import types
+
 from roslibpy import Service
 from roslibpy import ServiceRequest
 
@@ -30,6 +32,13 @@ class ServiceDescription(object):
 
     def call(self, client, request, callback, errback):
         def inner_handler(response_msg):
+            # IronPython sometimes decides it's a good idea to use an old-style class
+            # to pass the response_msg around, so we need to make sure we turn it into
+            # a proper ServiceResponse again
+            # https://github.com/compas-dev/compas_fab/issues/235
+            is_old_style_class = isinstance(response_msg, types.InstanceType)
+            if is_old_style_class:
+                response_msg = dict(response_msg)
             response_object = self.response_class.from_msg(response_msg)
 
             # Validate the response if there's a validator function assigned
@@ -39,14 +48,12 @@ class ServiceDescription(object):
                 except Exception as e:
                     errback(RosValidationError(e, response_object))
                     return
-
             callback(response_object)
 
         if isinstance(request, tuple):
             request_msg = self.request_class(*request)
         else:
             request_msg = self.request_class(**request)
-
         srv = Service(client, self.name, self.type)
         srv.call(ServiceRequest(request_msg.msg),
                  callback=inner_handler, errback=errback)

--- a/src/compas_fab/robots/tool.py
+++ b/src/compas_fab/robots/tool.py
@@ -37,17 +37,16 @@ class Tool(object):
     def __init__(self, visual, frame_in_tool0_frame, collision=None,
                  name="attached_tool", link_name=None):
         self.tool_model = ToolModel(visual, frame_in_tool0_frame, collision, name, link_name)
-        self.attached_collision_meshes = self.get_attached_collision_meshes()
 
     @classmethod
     def from_tool_model(cls, tool_model):
         tool = cls(None, None)
         tool.tool_model = tool_model
-        tool.attached_collision_meshes = tool.get_attached_collision_meshes()
         return tool
 
-    def get_attached_collision_meshes(self):
-        tool_attached_collision_meshes = []
+    @property
+    def attached_collision_meshes(self):
+        acms = []
         for link in self.tool_model.iter_links():
             for i, item in enumerate(link.collision):
                 meshes = Geometry._get_item_meshes(item)
@@ -55,8 +54,8 @@ class Tool(object):
                     collision_mesh_name = '{}_collision_{}'.format(link.name, i)
                     collision_mesh = CollisionMesh(mesh, collision_mesh_name)
                     attached_collision_mesh = AttachedCollisionMesh(collision_mesh, self.link_name, [self.link_name])
-                    tool_attached_collision_meshes.append(attached_collision_mesh)
-        return tool_attached_collision_meshes
+                    acms.append(attached_collision_mesh)
+        return acms
 
     @property
     def link_name(self):
@@ -65,7 +64,6 @@ class Tool(object):
     @link_name.setter
     def link_name(self, link_name):
         self.tool_model.link_name = link_name
-        self.attached_collision_meshes = self.get_attached_collision_meshes()  # rebuild ACMs
 
     @property
     def frame(self):

--- a/src/compas_fab/robots/tool.py
+++ b/src/compas_fab/robots/tool.py
@@ -89,7 +89,6 @@ class Tool(object):
     @data.setter
     def data(self, data):
         self.tool_model.data = data
-        self.attached_collision_meshes = self.get_attached_collision_meshes()
 
     @classmethod
     def from_data(cls, data):

--- a/src/compas_fab/robots/tool.py
+++ b/src/compas_fab/robots/tool.py
@@ -49,10 +49,11 @@ class Tool(object):
     def get_attached_collision_meshes(self):
         tool_attached_collision_meshes = []
         for link in self.tool_model.iter_links():
-            for item in link.collision:
+            for i, item in enumerate(link.collision):
                 meshes = Geometry._get_item_meshes(item)
                 for mesh in meshes:
-                    collision_mesh = CollisionMesh(item, mesh)
+                    collision_mesh_name = '{}_collision_{}'.format(link.name, i)
+                    collision_mesh = CollisionMesh(mesh, collision_mesh_name)
                     attached_collision_mesh = AttachedCollisionMesh(collision_mesh, self.link_name, [self.link_name])
                     tool_attached_collision_meshes.append(attached_collision_mesh)
         return tool_attached_collision_meshes
@@ -64,6 +65,7 @@ class Tool(object):
     @link_name.setter
     def link_name(self, link_name):
         self.tool_model.link_name = link_name
+        self.attached_collision_meshes = self.get_attached_collision_meshes()  # rebuild ACMs
 
     @property
     def frame(self):


### PR DESCRIPTION
This PR fixes two issues:
 - Attaching a tool was using a `frame_id=None` depending on the order of operations, so now we ensure the frame id is rebuilt if tool name changes
 - In some cases, IronPython uses an old-style class to represent the service response, which triggers an inner exception that is not handled and causes a freeze when used in GH.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
