### PR TITLE
Copy pybullet consts

### DIFF
--- a/src/compas_fab/backends/pybullet/const.py
+++ b/src/compas_fab/backends/pybullet/const.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 
 from collections import namedtuple
 
-from compas_fab.utilities import LazyLoader
-
 PYBULLET_GUI = 1
 PYBULLET_DIRECT = 2
 PYBULLET_SHARED_MEMORY = 3

--- a/src/compas_fab/backends/pybullet/const.py
+++ b/src/compas_fab/backends/pybullet/const.py
@@ -6,17 +6,24 @@ from collections import namedtuple
 
 from compas_fab.utilities import LazyLoader
 
-pybullet = LazyLoader('pybullet', globals(), 'pybullet')
+PYBULLET_GUI = 1
+PYBULLET_DIRECT = 2
+PYBULLET_SHARED_MEMORY = 3
+PYBULLET_UDP = 4
+PYBULLET_TCP = 5
+PYBULLET_GUI_SERVER = 7
+PYBULLET_SHARED_MEMORY_SERVER = 9
+PYBULLET_SHARED_MEMORY_GUI = 14
 
 CONNECTION_TYPE = {
-    'direct': pybullet.DIRECT,
-    'gui': pybullet.GUI,
-    'shared_memory': pybullet.SHARED_MEMORY,
-    'udp': pybullet.UDP,
-    'tcp': pybullet.TCP,
-    'gui_server': pybullet.GUI_SERVER,
-    'shared_memory_server': pybullet.SHARED_MEMORY_SERVER,
-    'shared_memory_gui': pybullet.SHARED_MEMORY_GUI,
+    'direct': PYBULLET_DIRECT,
+    'gui': PYBULLET_GUI,
+    'shared_memory': PYBULLET_SHARED_MEMORY,
+    'udp': PYBULLET_UDP,
+    'tcp': PYBULLET_TCP,
+    'gui_server': PYBULLET_GUI_SERVER,
+    'shared_memory_server': PYBULLET_SHARED_MEMORY_SERVER,
+    'shared_memory_gui': PYBULLET_SHARED_MEMORY_GUI,
 }
 
 BASE_LINK_ID = -1


### PR DESCRIPTION
Despite being lazy loaded, the `pybullet` library was loaded all the time due to the usage of some consts coming from the `pybullet` library, so instead of using them it's best to copy them.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
