### PR TITLE
Fix pybullet docs

### DIFF
--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_add_attached_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_add_attached_collision_mesh.py
@@ -35,7 +35,7 @@ class PyBulletAddAttachedCollisionMesh(AddAttachedCollisionMesh):
             - ``"max_force"``: (:obj:`float`) The maximum force that
               the constraint can apply. Optional.
             - ``"mass"``: (:obj:`float`) The mass of the object, in kg.
-            - ``"robot"``: (:class:`compas_fab.robots.Robot``) Robot instance
+            - ``"robot"``: (:class:`compas_fab.robots.Robot`) Robot instance
               to which the object should be attached.
 
         Returns

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
@@ -22,8 +22,8 @@ class PyBulletForwardKinematics(ForwardKinematics):
             full configuration is passed, the zero-joint state for the other
             configurable joints is assumed.
         group : str, optional
-            The planning group used for calculation. Defaults to the robot's
-            main planning group.
+            The planning group used for determining the end effector and labeling
+            the ``configuration``. Defaults to the robot's main planning group.
         options : dict, optional
             Dictionary containing the following key-value pairs:
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -38,13 +38,13 @@ class PyBulletInverseKinematics(InverseKinematics):
             joint positions differ the least from the start_configuration.
             Defaults to the zero configuration.
         group: str, optional
-            The planning group used for calculation. Defaults to the robot's
-            main planning group.
+            The planning group used for determining the end effector and labeling
+            the ``start_configuration``. Defaults to the robot's main planning group.
         options: dict, optional
             Dictionary containing the following key-value pairs:
 
             - ``"link_name"``: (:obj:`str`, optional ) Name of the link for which
-              to compute the inverse kinematics.  Defaults to the given robot's end
+              to compute the inverse kinematics.  Defaults to the given group's end
               effector.
             - ``"semi-constrained"``: (:obj:`bool`, optional) When ``True``, only the
               position and not the orientation of ``frame_WCF`` will not be considered


### PR DESCRIPTION
The pybullet docs suggest that the argument ``group`` is used in the calculation of ik/fk.  This is not the case.  I amended the docs to reflect this.  I also experimented with changing pybullet's ik to limit the calculation to a specific group without success.

Closes #229 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
