### PR TITLE
Switch to use compas.IPY

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Unreleased
 **Changed**
 
 * Updated to ``COMPAS 0.18``
+* Use ``compas.IPY`` to check for IronPython
 
 **Fixed**
 

--- a/src/compas_fab/backends/__init__.py
+++ b/src/compas_fab/backends/__init__.py
@@ -83,7 +83,7 @@ from .vrep.client import *              # noqa: F401,F403
 from .vrep.helpers import *             # noqa: F401,F403
 from .vrep.planner import *             # noqa: F401,F403
 
-if not compas.is_ironpython():
+if not compas.IPY:
     from .pybullet.client import *            # noqa: F401,F403
     from .pybullet.exceptions import *        # noqa: F401,F403
     from .pybullet.planner import *           # noqa: F401,F403

--- a/src/compas_fab/robots/wrench.py
+++ b/src/compas_fab/robots/wrench.py
@@ -6,7 +6,7 @@ import compas
 from compas.geometry import Vector
 from compas.geometry import cross_vectors
 
-if not compas.is_ironpython():
+if not compas.IPY:
     from scipy import stats
 else:
     stats = None


### PR DESCRIPTION
Totally insignificant PR to preemptively switch to `compas.IPY` since the function `is_ironpython` will go away from `compas` core.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
