### PR TITLE
Bump compas dependency to 0.19

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Unreleased
 
 **Changed**
 
+* Updated to ``COMPAS 0.19``
+
 **Fixed**
 
 **Deprecated**

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 requirements = [
     # Until COMPAS reaches 1.0, we pin major.minor and allow patch version updates
-    'compas>=0.18,<0.19',
+    'compas>=0.19,<0.20',
     'roslibpy>=1.1.0',
     'pybullet',
     'pyserial',

--- a/src/compas_fab/backends/pybullet/client.py
+++ b/src/compas_fab/backends/pybullet/client.py
@@ -8,7 +8,6 @@ import tempfile
 from itertools import combinations
 
 import compas
-from compas._os import system
 from compas.geometry import Frame
 from compas.robots import RobotModel
 
@@ -67,7 +66,7 @@ class PyBulletBase(object):
             self._configure_debug_visualizer(shadows)
 
     def _detect_display(self):
-        if self.connection_type == 'gui' and system != 'darwin' and not compas.is_windows() and ('DISPLAY' not in os.environ):
+        if self.connection_type == 'gui' and not compas.OSX and not compas.WINDOWS and ('DISPLAY' not in os.environ):
             self.connection_type = 'direct'
             print('No display detected! Continuing without GUI.')
 


### PR DESCRIPTION
To allow users to [#bugbash](https://github.com/compas-dev/compas/issues/694) using latest compas AND compas_fab:

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
