### PR TITLE
Add attached collision meshes to joint trajectories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,10 +13,13 @@ Unreleased
 **Added**
 
 * Added serialization methods to `compas_fab.robots.CollisionMesh` and `compas_fab.robots.AttachedCollisionMesh`
+* Added `attached_collision_meshes` attribute to `compas_fab.robots.JointTrajectory`
 
 **Changed**
 
 **Fixed**
+
+* Fixed bug existing since version 0.12 where `compas_fab.backends.RosClient.add_attached_collision_mesh` added collision objects to the scene, but did not attached them to the robot
 
 **Deprecated**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,14 +12,14 @@ Unreleased
 
 **Added**
 
-* Added serialization methods to `compas_fab.robots.CollisionMesh` and `compas_fab.robots.AttachedCollisionMesh`
-* Added `attached_collision_meshes` attribute to `compas_fab.robots.JointTrajectory`
+* Added serialization methods to ``compas_fab.robots.CollisionMesh`` and ``compas_fab.robots.AttachedCollisionMesh``
+* Added ``attached_collision_meshes`` attribute to ``compas_fab.robots.JointTrajectory``
 
 **Changed**
 
 **Fixed**
 
-* Fixed bug existing since version 0.12 where `compas_fab.backends.RosClient.add_attached_collision_mesh` added collision objects to the scene, but did not attached them to the robot
+* Fixed bug existing since version 0.12 where ``compas_fab.backends.RosClient.add_attached_collision_mesh`` added collision objects to the scene, but did not attached them to the robot
 
 **Deprecated**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Unreleased
 
 **Added**
 
+* Added serialization methods to `compas_fab.robots.CollisionMesh` and `compas_fab.robots.AttachedCollisionMesh`
+
 **Changed**
 
 **Fixed**

--- a/src/compas_fab/backends/ros/backend_features/move_it_add_attached_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_add_attached_collision_mesh.py
@@ -10,7 +10,7 @@ from compas_fab.backends.ros.messages import ApplyPlanningSceneResponse
 from compas_fab.backends.ros.messages import AttachedCollisionObject
 from compas_fab.backends.ros.messages import CollisionObject
 from compas_fab.backends.ros.messages import PlanningScene
-from compas_fab.backends.ros.messages import PlanningSceneWorld
+from compas_fab.backends.ros.messages import RobotState
 from compas_fab.backends.ros.service_description import ServiceDescription
 
 __all__ = [
@@ -53,7 +53,7 @@ class MoveItAddAttachedCollisionMesh(AddAttachedCollisionMesh):
         aco = AttachedCollisionObject.from_attached_collision_mesh(
             attached_collision_mesh)
         aco.object.operation = CollisionObject.ADD
-        world = PlanningSceneWorld(collision_objects=[aco.object])
-        scene = PlanningScene(world=world, is_diff=True)
+        robot_state = RobotState(attached_collision_objects=[aco], is_diff=True)
+        scene = PlanningScene(robot_state=robot_state, is_diff=True)
         request = dict(scene=scene)
         self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import itertools
+
 from compas.utilities import await_callback
 
 from compas_fab.backends.interfaces import PlanMotion
@@ -119,11 +121,11 @@ class MoveItPlanMotion(PlanMotion):
             name=start_configuration.joint_names,
             position=start_configuration.values)
         start_state = RobotState(
-            joint_state, MultiDOFJointState(header=header))
-        if options.get('attached_collision_meshes'):
-            for acm in options['attached_collision_meshes']:
-                aco = AttachedCollisionObject.from_attached_collision_mesh(acm)
-                start_state.attached_collision_objects.append(aco)
+            joint_state, MultiDOFJointState(header=header), is_diff=True)
+        attached_collision_meshes = options.get('attached_collision_meshes', [])
+        for acm in attached_collision_meshes:
+            aco = AttachedCollisionObject.from_attached_collision_mesh(acm)
+            start_state.attached_collision_objects.append(aco)
 
         # convert constraints
         goal_constraints = [convert_constraints_to_rosmsg(goal_constraints, header)]
@@ -159,6 +161,9 @@ class MoveItPlanMotion(PlanMotion):
             start_state = response.trajectory_start.joint_state
             start_state_types = [joint_type_by_name[name] for name in start_state.name]
             trajectory.start_configuration = Configuration(start_state.position, start_state_types, start_state.name)
+            trajectory.attached_collision_meshes = list(itertools.chain(*[
+                aco.to_attached_collision_meshes()
+                for aco in response.trajectory_start.attached_collision_objects]))
 
             callback(trajectory)
 

--- a/src/compas_fab/backends/ros/backend_features/move_it_remove_attached_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_remove_attached_collision_mesh.py
@@ -10,7 +10,7 @@ from compas_fab.backends.ros.messages import ApplyPlanningSceneResponse
 from compas_fab.backends.ros.messages import AttachedCollisionObject
 from compas_fab.backends.ros.messages import CollisionObject
 from compas_fab.backends.ros.messages import PlanningScene
-from compas_fab.backends.ros.messages import PlanningSceneWorld
+from compas_fab.backends.ros.messages import RobotState
 from compas_fab.backends.ros.service_description import ServiceDescription
 
 __all__ = [
@@ -53,7 +53,7 @@ class MoveItRemoveAttachedCollisionMesh(RemoveAttachedCollisionMesh):
         aco = AttachedCollisionObject()
         aco.object.id = id
         aco.object.operation = CollisionObject.REMOVE
-        world = PlanningSceneWorld(collision_objects=[aco.object])
-        scene = PlanningScene(world=world, is_diff=True)
+        robot_state = RobotState(attached_collision_objects=[aco], is_diff=True)
+        scene = PlanningScene(robot_state=robot_state, is_diff=True)
         request = dict(scene=scene)
         self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)

--- a/src/compas_fab/robots/planning_scene.py
+++ b/src/compas_fab/robots/planning_scene.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from compas.datastructures import Mesh
 from compas.geometry import Frame
 from compas.geometry import Scale
 
@@ -81,6 +82,53 @@ class CollisionMesh(object):
         self.mesh = self.mesh.copy()
         self.scale(scale_factor)
 
+    def to_data(self):
+        """Get the data dictionary that represents the collision mesh.
+
+        This can be used to reconstruct the :class:`CollisionMesh` instance.
+
+        Returns
+        -------
+        :obj:`dict`
+        """
+        return self.data
+
+    @classmethod
+    def from_data(cls, data):
+        """Construct a collision mesh from its data representation.
+
+        Parameters
+        ----------
+        data : :obj:`dict`
+            The data dictionary.
+
+        Returns
+        -------
+        :class:`CollisionMesh`
+             An instance of :class:`CollisionMesh`.
+        """
+        collision_mesh = cls(None, None)
+        collision_mesh.data = data
+        return collision_mesh
+
+    @property
+    def data(self):
+        """:obj:`dict` : The data representing the collision mesh."""
+        data_obj = {}
+        data_obj['id'] = self.id
+        data_obj['mesh'] = self.mesh.to_data()
+        data_obj['frame'] = self.frame.to_data()
+        data_obj['root_name'] = self.root_name
+
+        return data_obj
+
+    @data.setter
+    def data(self, data_obj):
+        self.id = data_obj['id']
+        self.mesh = Mesh.from_data(data_obj['mesh'])
+        self.frame = Frame.from_data(data_obj['frame'])
+        self.root_name = data_obj['root_name']
+
 
 class AttachedCollisionMesh(object):
     """Represents a collision mesh that is attached to a :class:`Robot`'s :class:`~compas.robots.Link`.
@@ -126,6 +174,53 @@ class AttachedCollisionMesh(object):
         self.link_name = link_name
         self.touch_links = touch_links if touch_links else [link_name]
         self.weight = weight
+
+    def to_data(self):
+        """Get the data dictionary that represents the attached collision mesh.
+
+        This can be used to reconstruct the :class:`AttachedCollisionMesh` instance.
+
+        Returns
+        -------
+        :obj:`dict`
+        """
+        return self.data
+
+    @classmethod
+    def from_data(cls, data):
+        """Construct an attached collision mesh from its data representation.
+
+        Parameters
+        ----------
+        data : :obj:`dict`
+            The data dictionary.
+
+        Returns
+        -------
+        :class:`AttachedCollisionMesh`
+             An instance of :class:`AttachedCollisionMesh`.
+        """
+        acm = cls(None, None)
+        acm.data = data
+        return acm
+
+    @property
+    def data(self):
+        """:obj:`dict` : The data representing the attached collision mesh."""
+        data_obj = {}
+        data_obj['collision_mesh'] = self.collision_mesh.to_data()
+        data_obj['link_name'] = self.link_name
+        data_obj['touch_links'] = self.touch_links
+        data_obj['weight'] = self.weight
+
+        return data_obj
+
+    @data.setter
+    def data(self, data_obj):
+        self.collision_mesh = CollisionMesh.from_data(data_obj['collision_mesh'])
+        self.link_name = data_obj['link_name']
+        self.touch_links = data_obj['touch_links']
+        self.weight = data_obj['weight']
 
 
 class PlanningScene(object):

--- a/src/compas_fab/robots/planning_scene.py
+++ b/src/compas_fab/robots/planning_scene.py
@@ -443,6 +443,11 @@ class PlanningScene(object):
         >>> group = robot.main_group_name
         >>> scene.attach_collision_mesh_to_robot_end_effector(cm, group=group)
 
+        >>> # check if it's really there
+        >>> planning_scene = robot.client.get_planning_scene()
+        >>> objects = [c.object['id'] for c in planning_scene.robot_state.attached_collision_objects]
+        >>> 'tip' in objects
+        True
         >>> scene.remove_attached_collision_mesh('tip')
 
         >>> # check if it's really gone

--- a/src/compas_fab/robots/trajectory.py
+++ b/src/compas_fab/robots/trajectory.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from compas_fab.robots import AttachedCollisionMesh
 from compas_fab.robots.time_ import Duration
 from compas_fab.robots.configuration import Configuration
 
@@ -293,12 +294,13 @@ class JointTrajectory(Trajectory):
         The data representing the trajectory.
     """
 
-    def __init__(self, trajectory_points=None, joint_names=None, start_configuration=None, fraction=None):
+    def __init__(self, trajectory_points=None, joint_names=None, start_configuration=None, fraction=None, attached_collision_meshes=None):
         super(Trajectory, self).__init__()
         self.points = trajectory_points or []
         self.joint_names = joint_names or []
         self.start_configuration = start_configuration
         self.fraction = fraction
+        self.attached_collision_meshes = attached_collision_meshes or []
 
     @classmethod
     def from_data(cls, data):
@@ -337,6 +339,7 @@ class JointTrajectory(Trajectory):
         data_obj['joint_names'] = self.joint_names or []
         data_obj['start_configuration'] = self.start_configuration.to_data() if self.start_configuration else None
         data_obj['fraction'] = self.fraction
+        data_obj['attached_collision_meshes'] = [acm.to_data() for acm in self.attached_collision_meshes]
 
         return data_obj
 
@@ -347,6 +350,7 @@ class JointTrajectory(Trajectory):
         if data.get('start_configuration'):
             self.start_configuration = Configuration.from_data(data.get('start_configuration'))
         self.fraction = data.get('fraction')
+        self.attached_collision_meshes = [AttachedCollisionMesh.from_data(acm_data) for acm_data in data.get('attached_collision_meshes')]
 
     @property
     def time_from_start(self):

--- a/src/compas_fab/robots/trajectory.py
+++ b/src/compas_fab/robots/trajectory.py
@@ -278,6 +278,8 @@ class JointTrajectory(Trajectory):
     fraction : :obj:`float`, optional
         Indicates the percentage of requested trajectory that was calculated,
         e.g. ``1`` means the full trajectory was found.
+    attached_collision_meshes : :obj:`list` of :closs:`compas_fab.robots.AttachedCollisionMesh`
+        The attached collision meshes included in the calculation of this trajectory.
 
     Attributes
     ----------
@@ -290,6 +292,8 @@ class JointTrajectory(Trajectory):
     fraction : :obj:`float`
         Indicates the percentage of requested trajectory that was calculated,
         e.g. ``1`` means the full trajectory was found.
+    attached_collision_meshes : :obj:`list` of :class:`compas_fab.robots.AttachedCollisionMesh`
+        The attached collision meshes included in the calculation of this trajectory.
     data : :obj:`dict`
         The data representing the trajectory.
     """


### PR DESCRIPTION
Closes #263.  While I was doing this, I noticed a pretty serious bug introduced with version 0.12.  `RosClient.add_attached_collision_mesh` was adding a collision mesh, but not attaching it.  So that's fixed here too.  

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
