### PR TITLE
Dictionary-like Configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Unreleased
 **Changed**
 
 * Updated to ``COMPAS 1.1``
+* ``compas_fab.robots.JointTrajectoryPoint.values`` became ``compas_fab.robots.JointTrajectoryPoint.joint_values``
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,7 @@ Unreleased
 * Added serialization methods to ``compas_fab.robots.CollisionMesh`` and ``compas_fab.robots.AttachedCollisionMesh``
 * Added ``attached_collision_meshes`` attribute to ``compas_fab.robots.JointTrajectory``
 * Added ``compas_fab.backends.ros.PlanningSceneComponents.__ne__``
-* Added read-only dictionary behave to ``compas_fab.robots.JointTrajectoryPoint.merge``
+* Added dictionary behavior to ``compas_fab.robots.JointTrajectoryPoint.merge``
 * Added length limitations to attributes of ``compas_fab.robots.JointTrajectoryPoint.merge``
 
 **Changed**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,7 @@ Unreleased
 **Changed**
 
 * Updated to ``COMPAS 1.1``
-* ``compas_fab.robots.JointTrajectoryPoint.values`` became ``compas_fab.robots.JointTrajectoryPoint.joint_values``
+* ``Configuration`` & ``JointTrajectoryPoint``: the attributes ``values`` and ``types`` changed to ``joint_values`` and `joint_types` respectively.
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Unreleased
 * Added ``compas_fab.robots.Robot.ensure_geometry``
 * Added serialization methods to ``compas_fab.robots.CollisionMesh`` and ``compas_fab.robots.AttachedCollisionMesh``
 * Added ``attached_collision_meshes`` attribute to ``compas_fab.robots.JointTrajectory``
+* Added read-only dictionary behave to ``compas_fab.robots.JointTrajectoryPoint.merge``
+* Added length limitations to attributes of ``compas_fab.robots.JointTrajectoryPoint.merge``
 
 **Changed**
 
@@ -44,6 +46,8 @@ Unreleased
 **Deprecated**
 
 **Removed**
+
+* Remove ``compas_fab.robots.JointTrajectoryPoint.merge``
 
 0.16.0
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+Unreleased
+----------
+
+**Added**
+
+**Changed**
+
+**Fixed**
+
+**Deprecated**
+
+**Removed**
+
 0.17.0
 ----------
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -129,5 +129,5 @@ class PyBulletInverseKinematics(InverseKinematics):
         return joint_positions, joint_names
 
     def _get_rest_poses(self, joint_names, configuration):
-        name_value_map = {configuration.joint_names[i]: configuration.values[i] for i in range(len(configuration.joint_names))}
+        name_value_map = {configuration.joint_names[i]: configuration.joint_values[i] for i in range(len(configuration.joint_names))}
         return [name_value_map[name] for name in joint_names]

--- a/src/compas_fab/backends/pybullet/client.py
+++ b/src/compas_fab/backends/pybullet/client.py
@@ -425,7 +425,7 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         body_id = self.get_uid(cached_robot)
         if configuration:
             joint_ids = self._get_joint_ids_by_name(configuration.joint_names, cached_robot)
-            self._set_joint_positions(joint_ids, configuration.values, body_id)
+            self._set_joint_positions(joint_ids, configuration.joint_values, body_id)
         self.check_collision_with_objects(robot)
         self.check_robot_self_collision(robot)
 
@@ -579,7 +579,7 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         default_config = robot.zero_configuration()
         full_configuration = robot.merge_group_with_full_configuration(configuration, default_config, group)
         joint_ids = self._get_joint_ids_by_name(full_configuration.joint_names, cached_robot)
-        self._set_joint_positions(joint_ids, full_configuration.values, body_id)
+        self._set_joint_positions(joint_ids, full_configuration.joint_values, body_id)
         return full_configuration
 
     def get_robot_configuration(self, robot):
@@ -598,7 +598,7 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         default_config = robot.zero_configuration()
         joint_ids = self._get_joint_ids_by_name(default_config.joint_names, cached_robot)
         joint_values = self._get_joint_positions(joint_ids, body_id)
-        default_config.values = joint_values
+        default_config.joint_values = joint_values
         return default_config
 
     # =======================================

--- a/src/compas_fab/backends/ros/backend_features/helpers.py
+++ b/src/compas_fab/backends/ros/backend_features/helpers.py
@@ -41,12 +41,12 @@ def convert_constraints_to_rosmsg(constraints, header):
     return ros_constraints
 
 
-def convert_trajectory_points(points, types):
+def convert_trajectory_points(points, joint_types):
     result = []
 
     for pt in points:
         jtp = JointTrajectoryPoint(joint_values=pt.positions,
-                                   types=types,
+                                   joint_types=joint_types,
                                    velocities=pt.velocities,
                                    accelerations=pt.accelerations,
                                    effort=pt.effort,

--- a/src/compas_fab/backends/ros/backend_features/helpers.py
+++ b/src/compas_fab/backends/ros/backend_features/helpers.py
@@ -45,7 +45,7 @@ def convert_trajectory_points(points, types):
     result = []
 
     for pt in points:
-        jtp = JointTrajectoryPoint(values=pt.positions,
+        jtp = JointTrajectoryPoint(joint_values=pt.positions,
                                    types=types,
                                    velocities=pt.velocities,
                                    accelerations=pt.accelerations,

--- a/src/compas_fab/backends/ros/backend_features/move_it_forward_kinematics.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_forward_kinematics.py
@@ -84,7 +84,7 @@ class MoveItForwardKinematics(ForwardKinematics):
 
         header = Header(frame_id=base_link)
         joint_state = JointState(
-            name=configuration.joint_names, position=configuration.values, header=header)
+            name=configuration.joint_names, position=configuration.joint_values, header=header)
         robot_state = RobotState(
             joint_state, MultiDOFJointState(header=header))
 

--- a/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
@@ -97,7 +97,7 @@ class MoveItInverseKinematics(InverseKinematics):
         pose_stamped = PoseStamped(header, Pose.from_frame(frame_WCF))
 
         joint_state = JointState(
-            name=start_configuration.joint_names, position=start_configuration.values, header=header)
+            name=start_configuration.joint_names, position=start_configuration.joint_values, header=header)
         start_state = RobotState(
             joint_state, MultiDOFJointState(header=header))
 

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_cartesian_motion.py
@@ -113,7 +113,7 @@ class MoveItPlanCartesianMotion(PlanCartesianMotion):
         waypoints = [Pose.from_frame(frame) for frame in frames_WCF]
         joint_state = JointState(header=header,
                                  name=start_configuration.joint_names,
-                                 position=start_configuration.values)
+                                 position=start_configuration.joint_values)
         start_state = RobotState(joint_state, MultiDOFJointState(header=header), is_diff=True)
 
         if options.get('attached_collision_meshes'):

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
@@ -119,7 +119,7 @@ class MoveItPlanMotion(PlanMotion):
         joint_state = JointState(
             header=header,
             name=start_configuration.joint_names,
-            position=start_configuration.values)
+            position=start_configuration.joint_values)
         start_state = RobotState(
             joint_state, MultiDOFJointState(header=header), is_diff=True)
 

--- a/src/compas_fab/backends/ros/client.py
+++ b/src/compas_fab/backends/ros/client.py
@@ -219,10 +219,10 @@ class RosClient(Ros, ClientInterface):
             timeout = timesteps[-1] * 1000 * 2
 
         points = []
-        num_joints = len(configurations[0].values)
+        num_joints = len(configurations[0].joint_values)
         for config, time in zip(configurations, timesteps):
-            pt = RosMsgJointTrajectoryPoint(positions=config.values, velocities=[
-                                      0]*num_joints, time_from_start=Time(secs=(time)))
+            pt = RosMsgJointTrajectoryPoint(positions=config.joint_values, velocities=[
+                                      0] * num_joints, time_from_start=Time(secs=(time)))
             points.append(pt)
 
         joint_trajectory = RosMsgJointTrajectory(

--- a/src/compas_fab/backends/vrep/client.py
+++ b/src/compas_fab/backends/vrep/client.py
@@ -223,7 +223,7 @@ class VrepClient(ClientInterface):
 
         values = config_to_vrep(config, self.scale)
 
-        self.set_robot_metric(robot.model.attr['index'], [0.0] * len(config.values))
+        self.set_robot_metric(robot.model.attr['index'], [0.0] * len(config.joint_values))
         self.run_child_script('moveRobotFK',
                               [], values, ['robot' + robot.name])
 

--- a/src/compas_fab/ghpython/components/compile.py
+++ b/src/compas_fab/ghpython/components/compile.py
@@ -5,7 +5,7 @@ from compas_fab.ghpython.components import get_ghpy_filename
 
 
 def compile(version):
-    pythonfiles = glob.glob("*.py")
+    pythonfiles = glob.glob('*.py')
     not_include = ['__init__.py', 'icons.py', 'install.py', os.path.basename(__file__)]
     pythonfiles = list(set(pythonfiles) - set(not_include))
     filename = get_ghpy_filename(version)

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 
 from math import pi
-from collections import UserDict
 from compas.robots import Joint
 
 __all__ = [
@@ -13,6 +12,8 @@ __all__ = [
 
 class Configuration(object):
     """Represents the configuration of a robot based on the state of its joints.
+    If the names of joints are also provided, the configuration behaves as a
+    read-only dictionary of joint name-value pairs.
 
     This concept is also refered to as \"Joint State\".
 
@@ -95,6 +96,15 @@ class Configuration(object):
                 return value
         raise KeyError(item)
 
+    def __bool__(self):
+        return bool(self.joint_values)
+
+    def __len__(self):
+        return len(self.joint_names)
+
+    def __iter__(self):
+        return iter(self.joint_names)
+
     def items(self):
         return zip(self.joint_names, self.joint_values)
 
@@ -103,6 +113,13 @@ class Configuration(object):
 
     def values(self):
         return iter(self.joint_values)
+
+    def get(self, key, default=None):
+        try:
+            value = self[key]
+        except KeyError:
+            value = default
+        return value
 
     @classmethod
     def from_revolute_values(cls, values, joint_names=None):

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -22,6 +22,14 @@ class FixedLengthList(list):
             raise TypeError('Cannot change length of FixedLengthList')
         super(FixedLengthList, self).__setitem__(key, value)
 
+    def __setslice__(self, i, j, sequence):
+        # for ironpython
+        slice_length = j - i
+        value_length = len(sequence)
+        if slice_length != value_length:
+            raise TypeError('Cannot change length of FixedLengthList')
+        super(FixedLengthList, self).__setslice__(key, value)
+
     def append(self, item): raise TypeError('Cannot change length of FixedLengthList')
     def extend(self, other): raise TypeError('Cannot change length of FixedLengthList')
     def insert(self, i, item): raise TypeError('Cannot change length of FixedLengthList')
@@ -148,6 +156,10 @@ class Configuration(object):
 
     def __bool__(self):
         return bool(self.joint_values)
+
+    def __nonzero__(self):
+        # ironpython's version of __bool__
+        return self.__bool__()
 
     def __len__(self):
         return len(self.joint_names)

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -28,7 +28,7 @@ class FixedLengthList(list):
         value_length = len(sequence)
         if slice_length != value_length:
             raise TypeError('Cannot change length of FixedLengthList')
-        super(FixedLengthList, self).__setslice__(key, value)
+        super(FixedLengthList, self).__setslice__(i, j, sequence)
 
     def append(self, item): raise TypeError('Cannot change length of FixedLengthList')
     def extend(self, other): raise TypeError('Cannot change length of FixedLengthList')

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -98,7 +98,7 @@ class Configuration(object):
         joint_names = FixedLengthList(joint_names or [])
 
         if len(joint_values) != len(types):
-            raise ValueError("%d joint_values must have %d types, but %d given." % (
+            raise ValueError('{} joint_values must have {} types, but {} given.'.format(
                 len(joint_values), len(joint_values), len(types)))
 
         self._precision = '3f'

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -12,7 +12,7 @@ __all__ = [
 
 
 def joint_names_validator(joint_names, key=None, value=None):
-    new_joint_names = joint_names.copy()
+    new_joint_names = list(joint_names)
     if key is not None and value is not None:
         new_joint_names.__setitem__(key, value)
     if len(new_joint_names) != len(set(new_joint_names)):

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -49,7 +49,8 @@ class FixedLengthList(list):
 
     def __setslice__(self, i, j, sequence):
         # for ironpython
-        slice_length = j - i
+        slice_end = min(j, self.__len__())
+        slice_length = slice_end - i
         value_length = len(sequence)
         if slice_length != value_length:
             raise TypeError('Cannot change length of FixedLengthList')

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 from math import pi
+from collections import UserDict
 from compas.robots import Joint
 
 __all__ = [
@@ -63,14 +64,18 @@ class Configuration(object):
     """
 
     def __init__(self, joint_values=None, types=None, joint_names=None):
-        self._precision = '3f'
-        self.joint_values = list(joint_values or [])
-        self.types = list(types or [])
-        self.joint_names = list(joint_names or [])
+        joint_values = list(joint_values or [])
+        types = list(types or [])
+        joint_names = list(joint_names or [])
 
-        if len(self.joint_values) != len(self.types):
+        if len(joint_values) != len(types):
             raise ValueError("%d joint_values must have %d types, but %d given." % (
-                len(self.joint_values), len(self.joint_values), len(self.types)))
+                len(joint_values), len(joint_values), len(types)))
+
+        self._precision = '3f'
+        self.joint_values = joint_values
+        self.types = types
+        self.joint_names = joint_names
 
     def __str__(self):
         """Return a human-readable string representation of the instance."""

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -21,10 +21,19 @@ def joint_names_validator(joint_names, key=None, value=None):
 
 class FixedLengthList(list):
     """Restriction of the standard Python list to prevent changes in length
-    while maintaining the ability to change values."""
-    def __init__(self, *args, validator=None, **kwargs):
+    while maintaining the ability to change values.  An optional ``validator``
+    can be passed to the constructor which would be used to validate changes
+    to the values.
+
+    Parameters
+    ----------
+    validator : :obj:`function`
+        A boolean function with the same signature as __setiem__, ie
+        validator(fll: FixedLengthList, key: slice, value: Any) -> bool
+    """
+    def __init__(self, *args, **kwargs):
         super(FixedLengthList, self).__init__(*args, **kwargs)
-        self.validator = validator
+        self.validator = kwargs.get('validator')
         if self.validator:
             self.validator(self)
 

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -32,7 +32,7 @@ class FixedLengthList(list):
         validator(fll: FixedLengthList, key: slice, value: Any) -> bool
     """
     def __init__(self, *args, **kwargs):
-        super(FixedLengthList, self).__init__(*args, **kwargs)
+        super(FixedLengthList, self).__init__(*args)
         self.validator = kwargs.get('validator')
         if self.validator:
             self.validator(self)

--- a/src/compas_fab/robots/configuration.py
+++ b/src/compas_fab/robots/configuration.py
@@ -59,7 +59,7 @@ class FixedLengthList(list):
 class Configuration(object):
     """Represents the configuration of a robot based on the state of its joints.
     If the names of joints are also provided, the configuration behaves as a
-    read-only dictionary of joint name-value pairs.
+    dictionary of joint name-value pairs.
 
     This concept is also refered to as \"Joint State\".
 

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -531,7 +531,7 @@ class Robot(object):
 
         full_configuration = self._check_full_configuration_and_scale(full_configuration)[0]  # adds joint_names to full_configuration and makes copy
 
-        full_configuration.merge(group_configuration)
+        full_configuration = full_configuration.merged(group_configuration)
         return full_configuration
 
     def get_group_names_from_link_name(self, link_name):

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -211,7 +211,7 @@ class Robot(object):
         """
         if not full_configuration:
             full_configuration = self.zero_configuration()
-        return self.model.forward_kinematics(full_configuration.joint_dict, link_name=self.get_end_effector_link_name(group))
+        return self.model.forward_kinematics(full_configuration, link_name=self.get_end_effector_link_name(group))
 
     def get_base_link_name(self, group=None):
         """Get the name of the robot's base link.
@@ -273,7 +273,7 @@ class Robot(object):
         """
         if not full_configuration:
             full_configuration = self.zero_configuration()
-        return self.model.forward_kinematics(full_configuration.joint_dict, link_name=self.get_base_link_name(group))
+        return self.model.forward_kinematics(full_configuration, link_name=self.get_base_link_name(group))
 
     def get_link_names(self, group=None):
         """Get the names of the links in the kinematic chain.
@@ -495,9 +495,8 @@ class Robot(object):
             The configuration of the group.
         """
         full_configuration = self._check_full_configuration_and_scale(full_configuration)[0]  # adds joint_names to full_configuration and makes copy
-        full_joint_state = full_configuration.joint_dict
         group_joint_names = self.get_configurable_joint_names(group)
-        values = [full_joint_state[name] for name in group_joint_names]
+        values = [full_configuration[name] for name in group_joint_names]
         return Configuration(values, self.get_configurable_joint_types(group), group_joint_names)
 
     def merge_group_with_full_configuration(self, group_configuration, full_configuration, group):
@@ -1279,7 +1278,7 @@ class Robot(object):
             if link not in self.get_link_names(group):
                 raise ValueError('Link name {} does not exist in planning group'.format(link))
 
-            frame_WCF = self.model.forward_kinematics(full_configuration.joint_dict, link)
+            frame_WCF = self.model.forward_kinematics(full_configuration, link)
 
         # Otherwise, pass everything down to the client
         else:
@@ -1600,7 +1599,7 @@ class Robot(object):
         """
         if not len(configuration.joint_names):
             configuration.joint_names = self.get_configurable_joint_names(group)
-        return self.model.transformed_frames(configuration.joint_dict)
+        return self.model.transformed_frames(configuration)
 
     def transformed_axes(self, configuration, group=None):
         """Get the robot's transformed axes.
@@ -1620,7 +1619,7 @@ class Robot(object):
         """
         if not len(configuration.joint_names):
             configuration.joint_names = self.get_configurable_joint_names(group)
-        return self.model.transformed_axes(configuration.joint_dict)
+        return self.model.transformed_axes(configuration)
 
     # ==========================================================================
     # drawing
@@ -1648,7 +1647,7 @@ class Robot(object):
         if not len(configuration.joint_names):
             configuration.joint_names = self.get_configurable_joint_names(group)
 
-        self.artist.update(configuration.joint_dict, visual, collision)
+        self.artist.update(configuration, visual, collision)
 
     def draw_visual(self):
         """Draw the robot's visual geometry using the defined :attr:`Robot.artist`."""

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -211,8 +211,7 @@ class Robot(object):
         """
         if not full_configuration:
             full_configuration = self.zero_configuration()
-        full_joint_state = dict(zip(full_configuration.joint_names, full_configuration.values))
-        return self.model.forward_kinematics(full_joint_state, link_name=self.get_end_effector_link_name(group))
+        return self.model.forward_kinematics(full_configuration.joint_dict, link_name=self.get_end_effector_link_name(group))
 
     def get_base_link_name(self, group=None):
         """Get the name of the robot's base link.
@@ -274,8 +273,7 @@ class Robot(object):
         """
         if not full_configuration:
             full_configuration = self.zero_configuration()
-        full_joint_state = dict(zip(full_configuration.joint_names, full_configuration.values))
-        return self.model.forward_kinematics(full_joint_state, link_name=self.get_base_link_name(group))
+        return self.model.forward_kinematics(full_configuration.joint_dict, link_name=self.get_base_link_name(group))
 
     def get_link_names(self, group=None):
         """Get the names of the links in the kinematic chain.
@@ -497,7 +495,7 @@ class Robot(object):
             The configuration of the group.
         """
         full_configuration = self._check_full_configuration_and_scale(full_configuration)[0]  # adds joint_names to full_configuration and makes copy
-        full_joint_state = dict(zip(full_configuration.joint_names, full_configuration.values))
+        full_joint_state = full_configuration.joint_dict
         group_joint_names = self.get_configurable_joint_names(group)
         values = [full_joint_state[name] for name in group_joint_names]
         return Configuration(values, self.get_configurable_joint_types(group), group_joint_names)
@@ -579,10 +577,10 @@ class Robot(object):
             match the configurable joints of the given `group`.
         """
         names = self.get_configurable_joint_names(group)
-        if len(names) != len(configuration.values):
+        if len(names) != len(configuration.joint_values):
             raise ValueError(
-                "Please pass a configuration with %d values or specify group" % len(names))
-        return configuration.values[names.index(joint_name)]
+                "Please pass a configuration with %d joint_values or specify group" % len(names))
+        return configuration.joint_values[names.index(joint_name)]
 
     def _check_full_configuration_and_scale(self, full_configuration=None):
         """Either create a full configuration or check if the passed full configuration is valid.
@@ -602,7 +600,7 @@ class Robot(object):
         else:
             joint_names = self.get_configurable_joint_names()  # full configuration
             # full_configuration might have passive joints specified as well, we allow this.
-            if len(joint_names) > len(full_configuration.values):
+            if len(joint_names) > len(full_configuration.joint_values):
                 raise ValueError("Please pass a configuration with {} values, for all configurable joints of the robot.".format(len(joint_names)))
             configuration = full_configuration.copy()
             if not configuration.joint_names:
@@ -1096,22 +1094,22 @@ class Robot(object):
             group = self.main_group_name
 
         joint_names = self.get_configurable_joint_names(group)
-        if len(joint_names) != len(configuration.values):
-            raise ValueError("The passed configuration has %d values, the group %s needs however: %d" % (
-                len(configuration.values), group, len(joint_names)))
+        if len(joint_names) != len(configuration.joint_values):
+            raise ValueError("The passed configuration has %d joint_values, the group %s needs however: %d" % (
+                len(configuration.joint_values), group, len(joint_names)))
         if len(tolerances_above) == 1:
             tolerances_above = tolerances_above * len(joint_names)
-        elif len(tolerances_above) != len(configuration.values):
-            raise ValueError("The passed configuration has %d values, the tolerances_above however: %d" % (
-                len(configuration.values), len(tolerances_above)))
+        elif len(tolerances_above) != len(configuration.joint_values):
+            raise ValueError("The passed configuration has %d joint_values, the tolerances_above however: %d" % (
+                len(configuration.joint_values), len(tolerances_above)))
         if len(tolerances_below) == 1:
             tolerances_below = tolerances_below * len(joint_names)
-        elif len(tolerances_below) != len(configuration.values):
-            raise ValueError("The passed configuration has %d values, the tolerances_below however: %d" % (
-                len(configuration.values), len(tolerances_below)))
+        elif len(tolerances_below) != len(configuration.joint_values):
+            raise ValueError("The passed configuration has %d joint_values, the tolerances_below however: %d" % (
+                len(configuration.joint_values), len(tolerances_below)))
 
         constraints = []
-        for name, value, tolerance_above, tolerance_below in zip(joint_names, configuration.values, tolerances_above, tolerances_below):
+        for name, value, tolerance_above, tolerance_below in zip(joint_names, configuration.joint_values, tolerances_above, tolerances_below):
             constraints.append(JointConstraint(name, value, tolerance_above, tolerance_below))
         return constraints
 
@@ -1270,8 +1268,6 @@ class Robot(object):
         full_configuration = self.merge_group_with_full_configuration(configuration, self.zero_configuration(), group)
         full_configuration, full_configuration_scaled = self._check_full_configuration_and_scale(full_configuration)
 
-        full_joint_state = dict(zip(full_configuration.joint_names, full_configuration.values))
-
         # If there's no client, we default to `model` solver if there is no other assigned.
         if not self.client:
             solver = solver or 'model'
@@ -1283,7 +1279,7 @@ class Robot(object):
             if link not in self.get_link_names(group):
                 raise ValueError('Link name {} does not exist in planning group'.format(link))
 
-            frame_WCF = self.model.forward_kinematics(full_joint_state, link)
+            frame_WCF = self.model.forward_kinematics(full_configuration.joint_dict, link)
 
         # Otherwise, pass everything down to the client
         else:
@@ -1489,8 +1485,8 @@ class Robot(object):
         >>> robot.client = RosClient()
         >>> robot.client.run()
         >>> configuration = Configuration.from_revolute_values([0.0, -1.5707, 0.0, -1.5707, 0.0, 0.0])
-        >>> tolerances_above = [math.radians(5)] * len(configuration.values)
-        >>> tolerances_below = [math.radians(5)] * len(configuration.values)
+        >>> tolerances_above = [math.radians(5)] * len(configuration.joint_values)
+        >>> tolerances_below = [math.radians(5)] * len(configuration.joint_values)
         >>> group = robot.main_group_name
         >>> goal_constraints = robot.constraints_from_configuration(configuration, tolerances_above, tolerances_below, group)
         >>> trajectory = robot.plan_motion(goal_constraints, start_configuration, group, {'planner_id': 'RRTConnectkConfigDefault'})
@@ -1604,8 +1600,7 @@ class Robot(object):
         """
         if not len(configuration.joint_names):
             configuration.joint_names = self.get_configurable_joint_names(group)
-        joint_state = dict(zip(configuration.joint_names, configuration.values))
-        return self.model.transformed_frames(joint_state)
+        return self.model.transformed_frames(configuration.joint_dict)
 
     def transformed_axes(self, configuration, group=None):
         """Get the robot's transformed axes.
@@ -1625,8 +1620,7 @@ class Robot(object):
         """
         if not len(configuration.joint_names):
             configuration.joint_names = self.get_configurable_joint_names(group)
-        joint_state = dict(zip(configuration.joint_names, configuration.values))
-        return self.model.transformed_axes(joint_state)
+        return self.model.transformed_axes(configuration.joint_dict)
 
     # ==========================================================================
     # drawing
@@ -1653,9 +1647,8 @@ class Robot(object):
 
         if not len(configuration.joint_names):
             configuration.joint_names = self.get_configurable_joint_names(group)
-        joint_state = dict(zip(configuration.joint_names, configuration.values))
 
-        self.artist.update(joint_state, visual, collision)
+        self.artist.update(configuration.joint_dict, visual, collision)
 
     def draw_visual(self):
         """Draw the robot's visual geometry using the defined :attr:`Robot.artist`."""

--- a/src/compas_fab/robots/trajectory.py
+++ b/src/compas_fab/robots/trajectory.py
@@ -29,7 +29,7 @@ class JointTrajectoryPoint(Configuration):
     joint_values : :obj:`list` of :obj:`float`, optional
         Joint values expressed in radians or meters, depending on the respective
         type.
-    types : :obj:`list` of :attr:`compas.robots.Joint.TYPE`, optional
+    joint_types : :obj:`list` of :attr:`compas.robots.Joint.TYPE`, optional
         Joint types, e.g. a :obj:`list` of
         :attr:`compas.robots.Joint.REVOLUTE` for revolute joints.
     velocities : :obj:`list` of :obj:`float`, optional
@@ -46,7 +46,7 @@ class JointTrajectoryPoint(Configuration):
     joint_values : :obj:`list` of :obj:`float`
         Joint values expressed in radians or meters, depending on the respective
         type.
-    types : :obj:`list` of :attr:`compas.robots.Joint.TYPE`
+    joint_types : :obj:`list` of :attr:`compas.robots.Joint.TYPE`
         Joint types, e.g. a :obj:`list` of
         :attr:`compas.robots.Joint.REVOLUTE` for revolute joints.
     velocities : :obj:`list` of :obj:`float`
@@ -63,8 +63,8 @@ class JointTrajectoryPoint(Configuration):
         The data representing the trajectory point.
     """
 
-    def __init__(self, joint_values=None, types=None, velocities=None, accelerations=None, effort=None, time_from_start=None, joint_names=None):
-        super(JointTrajectoryPoint, self).__init__(joint_values, types, joint_names)
+    def __init__(self, joint_values=None, joint_types=None, velocities=None, accelerations=None, effort=None, time_from_start=None, joint_names=None):
+        super(JointTrajectoryPoint, self).__init__(joint_values, joint_types, joint_names)
         self.velocities = velocities or len(self.joint_values) * [0.]
         self.accelerations = accelerations or len(self.joint_values) * [0.]
         self.effort = effort or len(self.joint_values) * [0.]
@@ -75,7 +75,7 @@ class JointTrajectoryPoint(Configuration):
         vs = '%.' + self._precision
         return 'JointTrajectoryPoint(({}), {}, ({}), ({}), ({}), {})'.format(
             ', '.join(vs % i for i in self.joint_values),
-            tuple(self.types),
+            tuple(self.joint_types),
             ', '.join(vs % i for i in self.velocities),
             ', '.join(vs % i for i in self.accelerations),
             ', '.join(vs % i for i in self.effort),
@@ -145,7 +145,7 @@ class JointTrajectoryPoint(Configuration):
     @data.setter
     def data(self, data):
         self._joint_values = FixedLengthList(data.get('joint_values') or [])
-        self._types = FixedLengthList(data.get('types') or [])
+        self._joint_types = FixedLengthList(data.get('joint_types') or [])
         self._velocities = FixedLengthList(data.get('velocities') or [])
         self._accelerations = FixedLengthList(data.get('accelerations') or [])
         self._effort = FixedLengthList(data.get('effort') or [])
@@ -222,12 +222,12 @@ class JointTrajectoryPoint(Configuration):
 
         joint_names = list(_joint_dict.keys())
         joint_values = [_joint_dict[name] for name in joint_names]
-        types = [_type_dict[name] for name in joint_names]
+        joint_types = [_type_dict[name] for name in joint_names]
         velocities = [_velocity_dict[name] for name in joint_names]
         accelerations = [_acceleration_dict[name] for name in joint_names]
         effort = [_effort_dict[name] for name in joint_names]
 
-        return JointTrajectoryPoint(joint_values, types, velocities, accelerations, effort, joint_names=joint_names)
+        return JointTrajectoryPoint(joint_values, joint_types, velocities, accelerations, effort, joint_names=joint_names)
 
 
 class Trajectory(object):

--- a/src/compas_fab/robots/trajectory.py
+++ b/src/compas_fab/robots/trajectory.py
@@ -20,12 +20,12 @@ class JointTrajectoryPoint(Configuration):
     A trajectory point is a sub-class of :class:`Configuration` extended
     with acceleration, effort and time from start information.
 
-    Trajectory points are defined either as *values + velocities and
-    accelerations*, or as *values + efforts*.
+    Trajectory points are defined either as *joint_values + velocities and
+    accelerations*, or as *joint_values + efforts*.
 
     Parameters
     ----------
-    values : :obj:`list` of :obj:`float`, optional
+    joint_values : :obj:`list` of :obj:`float`, optional
         Joint values expressed in radians or meters, depending on the respective
         type.
     types : :obj:`list` of :attr:`compas.robots.Joint.TYPE`, optional
@@ -42,7 +42,7 @@ class JointTrajectoryPoint(Configuration):
 
     Attributes
     ----------
-    values : :obj:`list` of :obj:`float`
+    joint_values : :obj:`list` of :obj:`float`
         Joint values expressed in radians or meters, depending on the respective
         type.
     types : :obj:`list` of :attr:`compas.robots.Joint.TYPE`
@@ -57,23 +57,23 @@ class JointTrajectoryPoint(Configuration):
     time_from_start : :class:`Duration`
         Duration of trajectory point counting from the start.
     positions : :obj:`list` of :obj:`float`
-        Alias of `values`.
+        Alias of `joint_values`.
     data : obj:`dict`
         The data representing the trajectory point.
     """
 
-    def __init__(self, values=None, types=None, velocities=None, accelerations=None, effort=None, time_from_start=None):
-        super(JointTrajectoryPoint, self).__init__(values, types)
-        self.velocities = velocities or len(self.values) * [0.]
-        self.accelerations = accelerations or len(self.values) * [0.]
-        self.effort = effort or len(self.values) * [0.]
+    def __init__(self, joint_values=None, types=None, velocities=None, accelerations=None, effort=None, time_from_start=None):
+        super(JointTrajectoryPoint, self).__init__(joint_values, types)
+        self.velocities = velocities or len(self.joint_values) * [0.]
+        self.accelerations = accelerations or len(self.joint_values) * [0.]
+        self.effort = effort or len(self.joint_values) * [0.]
         self.time_from_start = time_from_start or Duration(0, 0)
 
     def __str__(self):
         """Return a human-readable string representation of the instance."""
         vs = '%.' + self._precision
         return 'JointTrajectoryPoint(({}), {}, ({}), ({}), ({}), {})'.format(
-            ', '.join(vs % i for i in self.values),
+            ', '.join(vs % i for i in self.joint_values),
             tuple(self.types),
             ', '.join(vs % i for i in self.velocities),
             ', '.join(vs % i for i in self.accelerations),
@@ -83,8 +83,8 @@ class JointTrajectoryPoint(Configuration):
 
     @property
     def positions(self):
-        """:obj:`list` of :obj:`float` : Alias of `values`."""
-        return self.values
+        """:obj:`list` of :obj:`float` : Alias of `joint_values`."""
+        return self.joint_values
 
     @property
     def velocities(self):
@@ -93,9 +93,9 @@ class JointTrajectoryPoint(Configuration):
 
     @velocities.setter
     def velocities(self, velocities):
-        if len(self.values) != len(velocities):
+        if len(self.joint_values) != len(velocities):
             raise ValueError('Must have {} velocities, but {} given.'.format(
-                len(self.values), len(velocities)))
+                len(self.joint_values), len(velocities)))
 
         self._velocities = velocities
 
@@ -106,9 +106,9 @@ class JointTrajectoryPoint(Configuration):
 
     @accelerations.setter
     def accelerations(self, accelerations):
-        if len(self.values) != len(accelerations):
+        if len(self.joint_values) != len(accelerations):
             raise ValueError('Must have {} accelerations, but {} given.'.format(
-                len(self.values), len(accelerations)))
+                len(self.joint_values), len(accelerations)))
 
         self._accelerations = accelerations
 
@@ -119,9 +119,9 @@ class JointTrajectoryPoint(Configuration):
 
     @effort.setter
     def effort(self, effort):
-        if len(self.values) != len(effort):
+        if len(self.joint_values) != len(effort):
             raise ValueError('Must have {} efforts, but {} given.'.format(
-                len(self.values), len(effort)))
+                len(self.joint_values), len(effort)))
 
         self._effort = effort
 
@@ -143,7 +143,7 @@ class JointTrajectoryPoint(Configuration):
 
     @data.setter
     def data(self, data):
-        self.values = data.get('values') or []
+        self.joint_values = data.get('joint_values') or []
         self.types = data.get('types') or []
         self.velocities = data.get('velocities') or []
         self.accelerations = data.get('accelerations') or []
@@ -215,7 +215,7 @@ class JointTrajectoryPoint(Configuration):
         _effort_dict.update(other.effort_dict)
 
         self.joint_names = list(_joint_dict.keys())
-        self.values = [_joint_dict[name] for name in self.joint_names]
+        self.joint_values = [_joint_dict[name] for name in self.joint_names]
         self.types = [_type_dict[name] for name in self.joint_names]
         self.velocities = [_velocity_dict[name] for name in self.joint_names]
         self.accelerations = [_acceleration_dict[name] for name in self.joint_names]

--- a/tests/robots/test_configuration.py
+++ b/tests/robots/test_configuration.py
@@ -2,31 +2,34 @@ import pytest
 from math import pi
 
 from compas.robots import Joint
-from compas_fab.robots import Configuration
+from compas_fab.robots import Configuration, FixedLengthList
 from compas_fab.robots import JointTrajectoryPoint
 from compas_fab.robots import to_degrees
 
 
 def test_bool():
-    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
+    config = Configuration(joint_values=[1, 2, 3], joint_types=[Joint.REVOLUTE] * 3, joint_names=['a', 'b', 'c'])
     assert config
 
-    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3)
+    config = Configuration(joint_values=[1, 2, 3], joint_types=[Joint.REVOLUTE] * 3)
+    assert config
+
+    config = Configuration()
     assert config
 
 
 def test_len():
-    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
+    config = Configuration(joint_values=[1, 2, 3], joint_types=[Joint.REVOLUTE] * 3, joint_names=['a', 'b', 'c'])
     assert len(config) == 3
 
-    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3)
+    config = Configuration(joint_values=[1, 2, 3], joint_types=[Joint.REVOLUTE] * 3)
     assert len(config) == 0
 
 
 def test_revolute_ctor():
     q = [4.5, 1.7, 0.5, 2.1, 0.1, 2.1]
     config = Configuration.from_revolute_values(q)
-    assert config.types == [Joint.REVOLUTE] * 6
+    assert config.joint_types == [Joint.REVOLUTE] * 6
 
     config = Configuration.from_revolute_values([pi/2, 0., 0.])
     assert to_degrees(config.joint_values) == [90, 0, 0]
@@ -36,21 +39,21 @@ def test_prismatic_revolute_ctor():
     config = Configuration.from_prismatic_and_revolute_values(
         [8.312], [1.5, 0., 0., 0., 1., 0.8])
     assert config.joint_values == [8.312, 1.5, 0., 0., 0., 1., 0.8]
-    assert config.types == [Joint.PRISMATIC] + [Joint.REVOLUTE] * 6
+    assert config.joint_types == [Joint.PRISMATIC] + [Joint.REVOLUTE] * 6
 
 
 def test_ctor():
     values = [1., 3., 0.1]
-    types = [Joint.REVOLUTE, Joint.PRISMATIC, Joint.PLANAR]
-    config = Configuration(values, types)
+    joint_types = [Joint.REVOLUTE, Joint.PRISMATIC, Joint.PLANAR]
+    config = Configuration(values, joint_types)
     assert config.joint_values == values
-    assert config.types == types
+    assert config.joint_types == joint_types
 
 
 def test_scale():
     values = [1.5, 1., 2.]
-    types = [Joint.REVOLUTE, Joint.PRISMATIC, Joint.PLANAR]
-    config = Configuration(values, types)
+    joint_types = [Joint.REVOLUTE, Joint.PRISMATIC, Joint.PLANAR]
+    config = Configuration(values, joint_types)
     config.scale(1000.)
 
     assert config.joint_values == [1.5, 1000., 2000.]
@@ -63,54 +66,133 @@ def test_cast_to_str():
 
 def test_from_data():
     config = Configuration.from_data(dict(joint_values=[8.312, 1.5],
-                                          types=[Joint.PRISMATIC, Joint.REVOLUTE]))
+                                          joint_types=[Joint.PRISMATIC, Joint.REVOLUTE]))
     assert str(config) == 'Configuration((8.312, 1.500), (2, 0))'
 
 
 def test_to_data():
     config = Configuration.from_prismatic_and_revolute_values(
         [8.312], [1.5, 0., 0., 0., 1., 0.8])
-    # types=[Joint.PRISMATIC, Joint.REVOLUTE]))
+    # joint_types=[Joint.PRISMATIC, Joint.REVOLUTE]))
     data = config.to_data()
 
     assert data['joint_values'] == [8.312, 1.5, 0., 0., 0., 1., 0.8]
-    assert data['types'] == [Joint.PRISMATIC] + [Joint.REVOLUTE] * 6
+    assert data['joint_types'] == [Joint.PRISMATIC] + [Joint.REVOLUTE] * 6
 
 
 def test_config_merged():
-    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
-    other_config = Configuration(joint_values=[3, 2, 0], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'd'])
+    config = Configuration(joint_values=[1, 2, 3], joint_types=[Joint.REVOLUTE] * 3, joint_names=['a', 'b', 'c'])
+    other_config = Configuration(joint_values=[3, 2, 0], joint_types=[Joint.REVOLUTE] * 3, joint_names=['a', 'b', 'd'])
     new_config = config.merged(other_config)
     assert new_config.joint_dict == {'a': 3, 'b': 2, 'c': 3, 'd': 0}
 
 
 def test_joint_trajectory_point_merged():
-    tjp = JointTrajectoryPoint(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, velocities=[4, 5, 6])
+    tjp = JointTrajectoryPoint(joint_values=[1, 2, 3], joint_types=[Joint.REVOLUTE] * 3, velocities=[4, 5, 6])
     tjp.joint_names = ['a', 'b', 'c']
-    other_tjp = JointTrajectoryPoint(joint_values=[3, 2, 0], types=[Joint.REVOLUTE]*3, velocities=[0, 5, 0])
+    other_tjp = JointTrajectoryPoint(joint_values=[3, 2, 0], joint_types=[Joint.REVOLUTE] * 3, velocities=[0, 5, 0])
     other_tjp.joint_names = ['a', 'b', 'd']
     new_tjp = tjp.merged(other_tjp)
     assert new_tjp.joint_dict == {'a': 3, 'b': 2, 'c': 3, 'd': 0}
     assert new_tjp.velocity_dict == {'a': 0, 'b': 5, 'c': 6, 'd': 0}
 
 
-def test_dict_behavior():
-    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
-    assert list(config.items()) == [('a', 1), ('b', 2), ('c', 3)]
+def test_joint_names():
+    with pytest.raises(ValueError):
+        config = Configuration(joint_values=[1, 2], joint_types=[Joint.REVOLUTE] * 2, joint_names=['a', 'a'])
+
+    config = Configuration(joint_values=[1, 2], joint_types=[Joint.REVOLUTE] * 2, joint_names=['a', 'b'])
+    with pytest.raises(ValueError):
+        config.joint_names = ['a', 'a']
+
+    with pytest.raises(ValueError):
+        config.joint_names[1] = config.joint_names[0]
+
+
+def test_dict_iterables():
+    config = Configuration(joint_values=[1, 2, 0], joint_types=[Joint.REVOLUTE] * 3, joint_names=['a', 'b', 'c'])
+    assert list(config.items()) == [('a', 1), ('b', 2), ('c', 0)]
     assert list(config.keys()) == ['a', 'b', 'c']
-    assert list(config.values()) == [1, 2, 3]
+    assert list(config.values()) == [1, 2, 0]
+
+
+def test___getitem__():
+    config = Configuration(joint_values=[1, 2, 0], joint_types=[Joint.REVOLUTE] * 3, joint_names=['a', 'b', 'c'])
     with pytest.raises(KeyError):
         _ = config['DNE']
     assert config['a'] == 1
     config.joint_values[0] = 4
     assert config['a'] == 4
-    assert config.get('a') == 4
+
+
+def test_get():
+    config = Configuration(joint_values=[1, 2, 0], joint_types=[Joint.REVOLUTE] * 3, joint_names=['a', 'b', 'c'])
+    assert config.get('a') == 1
     assert config.get('DNE') is None
     assert config.get('DNE', 5) == 5
-    with pytest.raises(TypeError):
-        config['a'] = 1
+    assert config.get('c', 5) == 0
+
+
+def test_fixed_length():
+    config = Configuration(joint_values=[1, 2, 0], joint_types=[Joint.REVOLUTE] * 3, joint_names=['a', 'b', 'c'])
     with pytest.raises(TypeError):
         config.joint_names.append('d')
     with pytest.raises(TypeError):
-        config.types[1:1] = range(5)
+        config.joint_types[1:1] = range(5)
 
+
+def test_fixed_length_list():
+    fll = FixedLengthList([1, 2, 3])
+    assert len(fll) == 3
+
+
+def test___setitem__():
+    fll = FixedLengthList([1, 2, 3])
+    fll[2] = 4
+    assert fll[2] == 4
+    fll[:1] = [5]
+    assert fll[0] == 5
+    with pytest.raises(TypeError):
+        fll[1:1] = range(10)
+
+
+def test___setitem___with_validator():
+    def validator(fixed_length_list, key=None, value=None):
+        new_fixed_length_list = fixed_length_list.copy()
+        if key is not None and value is not None:
+            new_fixed_length_list.__setitem__(key, value)
+        if len(new_fixed_length_list) != len(set(new_fixed_length_list)):
+            raise ValueError('joint_names cannot have repeated values.')
+    fll = FixedLengthList([1, 2, 3], validator=validator)
+    with pytest.raises(ValueError):
+        _ = FixedLengthList([1, 1, 1], validator=validator)
+    fll[2] = 4
+    assert fll[2] == 4
+    fll[1:] = [0, -1]
+    assert fll[0] == 1
+    assert fll[1] == 0
+    assert fll[2] == -1
+    with pytest.raises(TypeError):
+        fll[1:1] = range(10)
+    with pytest.raises(ValueError):
+        fll[1] = 1
+    with pytest.raises(ValueError):
+        fll[1:] = [0, 0]
+
+
+def test_length_altering_ops():
+    fll = FixedLengthList([1, 2, 3])
+    with pytest.raises(TypeError):
+        fll.append(4)
+    with pytest.raises(TypeError):
+        fll.extend([4])
+    with pytest.raises(TypeError):
+        _ = fll.pop()
+    with pytest.raises(TypeError):
+        fll.clear()
+    with pytest.raises(TypeError):
+        fll.insert(1, 7)
+    with pytest.raises(TypeError):
+        fll.remove(1)
+    with pytest.raises(TypeError):
+        fll.remove(7)

--- a/tests/robots/test_configuration.py
+++ b/tests/robots/test_configuration.py
@@ -60,18 +60,18 @@ def test_to_data():
     assert data['types'] == [Joint.PRISMATIC] + [Joint.REVOLUTE] * 6
 
 
-def test_config_merge():
+def test_config_merged():
     config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
     other_config = Configuration(joint_values=[3, 2, 0], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'd'])
-    config.merge(other_config)
-    assert config.joint_dict == {'a': 3, 'b': 2, 'c': 3, 'd': 0}
+    new_config = config.merged(other_config)
+    assert new_config.joint_dict == {'a': 3, 'b': 2, 'c': 3, 'd': 0}
 
 
-def test_joint_trajectory_point_merge():
+def test_joint_trajectory_point_merged():
     tjp = JointTrajectoryPoint(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, velocities=[4, 5, 6])
     tjp.joint_names = ['a', 'b', 'c']
     other_tjp = JointTrajectoryPoint(joint_values=[3, 2, 0], types=[Joint.REVOLUTE]*3, velocities=[0, 5, 0])
     other_tjp.joint_names = ['a', 'b', 'd']
-    tjp.merge(other_tjp)
-    assert tjp.joint_dict == {'a': 3, 'b': 2, 'c': 3, 'd': 0}
-    assert tjp.velocity_dict == {'a': 0, 'b': 5, 'c': 6, 'd': 0}
+    new_tjp = tjp.merged(other_tjp)
+    assert new_tjp.joint_dict == {'a': 3, 'b': 2, 'c': 3, 'd': 0}
+    assert new_tjp.velocity_dict == {'a': 0, 'b': 5, 'c': 6, 'd': 0}

--- a/tests/robots/test_configuration.py
+++ b/tests/robots/test_configuration.py
@@ -159,7 +159,7 @@ def test___setitem__():
 
 def test___setitem___with_validator():
     def validator(fixed_length_list, key=None, value=None):
-        new_fixed_length_list = fixed_length_list.copy()
+        new_fixed_length_list = list(fixed_length_list)
         if key is not None and value is not None:
             new_fixed_length_list.__setitem__(key, value)
         if len(new_fixed_length_list) != len(set(new_fixed_length_list)):

--- a/tests/robots/test_configuration.py
+++ b/tests/robots/test_configuration.py
@@ -12,13 +12,13 @@ def test_revolute_ctor():
     assert config.types == [Joint.REVOLUTE] * 6
 
     config = Configuration.from_revolute_values([pi/2, 0., 0.])
-    assert to_degrees(config.values) == [90, 0, 0]
+    assert to_degrees(config.joint_values) == [90, 0, 0]
 
 
 def test_prismatic_revolute_ctor():
     config = Configuration.from_prismatic_and_revolute_values(
         [8.312], [1.5, 0., 0., 0., 1., 0.8])
-    assert config.values == [8.312, 1.5, 0., 0., 0., 1., 0.8]
+    assert config.joint_values == [8.312, 1.5, 0., 0., 0., 1., 0.8]
     assert config.types == [Joint.PRISMATIC] + [Joint.REVOLUTE] * 6
 
 
@@ -26,7 +26,7 @@ def test_ctor():
     values = [1., 3., 0.1]
     types = [Joint.REVOLUTE, Joint.PRISMATIC, Joint.PLANAR]
     config = Configuration(values, types)
-    assert config.values == values
+    assert config.joint_values == values
     assert config.types == types
 
 
@@ -36,7 +36,7 @@ def test_scale():
     config = Configuration(values, types)
     config.scale(1000.)
 
-    assert config.values == [1.5, 1000., 2000.]
+    assert config.joint_values == [1.5, 1000., 2000.]
 
 
 def test_cast_to_str():
@@ -45,7 +45,7 @@ def test_cast_to_str():
 
 
 def test_from_data():
-    config = Configuration.from_data(dict(values=[8.312, 1.5],
+    config = Configuration.from_data(dict(joint_values=[8.312, 1.5],
                                           types=[Joint.PRISMATIC, Joint.REVOLUTE]))
     assert str(config) == 'Configuration((8.312, 1.500), (2, 0))'
 
@@ -56,21 +56,21 @@ def test_to_data():
     # types=[Joint.PRISMATIC, Joint.REVOLUTE]))
     data = config.to_data()
 
-    assert data['values'] == [8.312, 1.5, 0., 0., 0., 1., 0.8]
+    assert data['joint_values'] == [8.312, 1.5, 0., 0., 0., 1., 0.8]
     assert data['types'] == [Joint.PRISMATIC] + [Joint.REVOLUTE] * 6
 
 
 def test_config_merge():
-    config = Configuration(values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
-    other_config = Configuration(values=[3, 2, 0], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'd'])
+    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
+    other_config = Configuration(joint_values=[3, 2, 0], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'd'])
     config.merge(other_config)
     assert config.joint_dict == {'a': 3, 'b': 2, 'c': 3, 'd': 0}
 
 
 def test_joint_trajectory_point_merge():
-    tjp = JointTrajectoryPoint(values=[1, 2, 3], types=[Joint.REVOLUTE]*3, velocities=[4, 5, 6])
+    tjp = JointTrajectoryPoint(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, velocities=[4, 5, 6])
     tjp.joint_names = ['a', 'b', 'c']
-    other_tjp = JointTrajectoryPoint(values=[3, 2, 0], types=[Joint.REVOLUTE]*3, velocities=[0, 5, 0])
+    other_tjp = JointTrajectoryPoint(joint_values=[3, 2, 0], types=[Joint.REVOLUTE]*3, velocities=[0, 5, 0])
     other_tjp.joint_names = ['a', 'b', 'd']
     tjp.merge(other_tjp)
     assert tjp.joint_dict == {'a': 3, 'b': 2, 'c': 3, 'd': 0}

--- a/tests/robots/test_configuration.py
+++ b/tests/robots/test_configuration.py
@@ -1,9 +1,26 @@
+import pytest
 from math import pi
 
 from compas.robots import Joint
 from compas_fab.robots import Configuration
 from compas_fab.robots import JointTrajectoryPoint
 from compas_fab.robots import to_degrees
+
+
+def test_bool():
+    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
+    assert config
+
+    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3)
+    assert config
+
+
+def test_len():
+    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
+    assert len(config) == 3
+
+    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3)
+    assert len(config) == 0
 
 
 def test_revolute_ctor():
@@ -75,3 +92,25 @@ def test_joint_trajectory_point_merged():
     new_tjp = tjp.merged(other_tjp)
     assert new_tjp.joint_dict == {'a': 3, 'b': 2, 'c': 3, 'd': 0}
     assert new_tjp.velocity_dict == {'a': 0, 'b': 5, 'c': 6, 'd': 0}
+
+
+def test_dict_behavior():
+    config = Configuration(joint_values=[1, 2, 3], types=[Joint.REVOLUTE]*3, joint_names=['a', 'b', 'c'])
+    assert list(config.items()) == [('a', 1), ('b', 2), ('c', 3)]
+    assert list(config.keys()) == ['a', 'b', 'c']
+    assert list(config.values()) == [1, 2, 3]
+    with pytest.raises(KeyError):
+        _ = config['DNE']
+    assert config['a'] == 1
+    config.joint_values[0] = 4
+    assert config['a'] == 4
+    assert config.get('a') == 4
+    assert config.get('DNE') is None
+    assert config.get('DNE', 5) == 5
+    with pytest.raises(TypeError):
+        config['a'] = 1
+    with pytest.raises(TypeError):
+        config.joint_names.append('d')
+    with pytest.raises(TypeError):
+        config.types[1:1] = range(5)
+

--- a/tests/robots/test_configuration.py
+++ b/tests/robots/test_configuration.py
@@ -163,7 +163,7 @@ def test___setitem___with_validator():
         if key is not None and value is not None:
             new_fixed_length_list.__setitem__(key, value)
         if len(new_fixed_length_list) != len(set(new_fixed_length_list)):
-            raise ValueError('joint_names cannot have repeated values.')
+            raise ValueError('This list cannot have repeated values.')
     fll = FixedLengthList([1, 2, 3], validator=validator)
     with pytest.raises(ValueError):
         _ = FixedLengthList([1, 1, 1], validator=validator)
@@ -175,6 +175,12 @@ def test___setitem___with_validator():
     assert fll[2] == -1
     with pytest.raises(TypeError):
         fll[1:1] = range(10)
+    with pytest.raises(TypeError):
+        fll[1:] = [1]
+    with pytest.raises(TypeError):
+        fll[:] = [1, 2]
+    with pytest.raises(TypeError):
+        fll[:1] = [1, 2]
     with pytest.raises(ValueError):
         fll[1] = 1
     with pytest.raises(ValueError):

--- a/tests/robots/test_configuration.py
+++ b/tests/robots/test_configuration.py
@@ -2,7 +2,8 @@ import pytest
 from math import pi
 
 from compas.robots import Joint
-from compas_fab.robots import Configuration, FixedLengthList
+from compas_fab.robots import Configuration
+from compas_fab.robots import FixedLengthList
 from compas_fab.robots import JointTrajectoryPoint
 from compas_fab.robots import to_degrees
 


### PR DESCRIPTION
This is an attempt to make `Configuration` behave in some ways like a read-only dictionary, returning a joint value for a joint name key.  It is also an attempt to make the attributes like `joint_names` and `joint_values` semi-immutable in the sense that their lengths cannot change but their values can.  `FixedLengthList` subclasses `list` and overwrites many methods.  Please look over that carefully, and suggest meaningful tests.  That class is defined in `configuration.py` because it will only be there for a hot minute.  It too will migrate to compas core.  I haven't added an entry to the changelog for the same reason.  But at the same time, I wonder where best to announce the breaking change of `values` to `joint_values`, and the removal of `merge`.  

PS.  I just noticed that as part of the move I should probably update the PR template.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.Configuration`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
