### PR TITLE
fix use of getattr

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Unreleased
 
 * Fix ``repr()`` of ``ROSmsg`` class
 * Fix data type of secs and nsecs in ``Time`` ROS message
+* Fix ``CollisionObject.to_collision_meshes``   
 
 **Deprecated**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Unreleased
 
 * Fix ``repr()`` of ``ROSmsg`` class
 * Fix data type of secs and nsecs in ``Time`` ROS message
-* Fix ``CollisionObject.to_collision_meshes``   
+* Fix ``CollisionObject.to_collision_meshes``
 
 **Deprecated**
 

--- a/src/compas_fab/backends/ros/messages/moveit_msgs.py
+++ b/src/compas_fab/backends/ros/messages/moveit_msgs.py
@@ -103,7 +103,7 @@ class CollisionObject(ROSmsg):
                 vertex.x = float(vertex.x)
                 vertex.y = float(vertex.y)
                 vertex.z = float(vertex.z)
-            root_name = getattr(self.header, 'frame_id', self.header['frame_id'])
+            root_name = getattr(self.header, 'frame_id', None) or self.header['frame_id']
             cm = CollisionMesh(mesh.mesh, self.id, pose.frame, root_name)
             collision_meshes.append(cm)
         return collision_meshes


### PR DESCRIPTION
Fixes bug where the header of a collision mesh is treated as a dictionary rather than a ROSmsg.  

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
