### PR TITLE
When deserializing from data, ctor of ACM fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Unreleased
 * Fixed data type of secs and nsecs in ``Time`` ROS message
 * Fixed ``CollisionObject.to_collision_meshes``
 * Fixed serialization of joint names for ``compas_fab.robots.JointTrajectoryPoint``
+* Fixed deserialization of ``AttachedCollisionMesh``
 
 **Deprecated**
 

--- a/src/compas_fab/robots/planning_scene.py
+++ b/src/compas_fab/robots/planning_scene.py
@@ -170,7 +170,8 @@ class AttachedCollisionMesh(object):
 
     def __init__(self, collision_mesh, link_name, touch_links=None, weight=1.):
         self.collision_mesh = collision_mesh
-        self.collision_mesh.root_name = link_name
+        if self.collision_mesh:
+            self.collision_mesh.root_name = link_name
         self.link_name = link_name
         self.touch_links = touch_links if touch_links else [link_name]
         self.weight = weight


### PR DESCRIPTION
The collision_mesh param is empty, but its root_name has been set already, so, instead we don't try to do reassign it, it will be deserialized from data.

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
