### PR TITLE
Change temp file name in convert_mesh_to_body

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Unreleased
 
 **Fixed**
 
+* Fixed bug in ``compas.backends.PyBulletClient.convert_mesh_to_body`` circumventing PyBullet's propensity to cache
+
 **Deprecated**
 
 **Removed**
@@ -51,8 +53,8 @@ Unreleased
 
 **Changed**
 
-* The `Configuration` class has moved to `compas.robots`, but is still aliased within `compas_fab.robots`
-* Lazily load `V-REP remoteApi` library
+* The ``Configuration`` class has moved to ``compas.robots``, but is still aliased within ``compas_fab.robots``
+* Lazily load ``V-REP remoteApi`` library
 
 **Fixed**
 
@@ -64,7 +66,7 @@ Unreleased
 
 **Deprecated**
 
-* `compas_fab.robots.Configuration` is being deprecated in favor of `compas.robots.Configuration`
+* ``compas_fab.robots.Configuration`` is being deprecated in favor of ``compas.robots.Configuration``
 
 0.17.0
 ----------

--- a/src/compas_fab/backends/pybullet/client.py
+++ b/src/compas_fab/backends/pybullet/client.py
@@ -622,7 +622,7 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         -------
         :obj:`int`
         """
-        tmp_obj_path = os.path.join(self._cache_dir.name, 'temp.obj')
+        tmp_obj_path = os.path.join(self._cache_dir.name, '{}.obj'.format(mesh.guid))
         mesh.to_obj(tmp_obj_path)
         tmp_obj_path = self._handle_concavity(tmp_obj_path, self._cache_dir.name, concavity, mass)
         pyb_body_id = self.body_from_obj(tmp_obj_path, concavity=concavity, mass=mass)


### PR DESCRIPTION
Closes #305   PyBullet, by default, caches the contents of obj's that it has loaded.  If it encounters a recognized path to an obj, it assumes the contents are the same as when it first read it.  Previously all the meshes were stored in `some/temp/dir/temp.obj`.  Now they will be stored in `some/temp/dir/{mesh.guid}.obj`.   I don't want to disable cacheing entirely, because that would effect performance.  I also don't want to return to having a new temp dir every time `convert_mesh_to_body` is called, because that is essentially turning off cacheing.  @gonzalocasas is this sufficient?  Given the way `mesh.uuid` is created (that is, lazily created when `guid` is called, but not modified when the mesh changes), the problem still exists for the following code:
```
from compas.datastructures import Mesh
from compas.geometry import Translation

import compas_fab
from compas_fab.backends.pybullet import PyBulletClient
from compas_fab.robots import CollisionMesh

with PyBulletClient() as client:
    mesh = Mesh.from_stl(compas_fab.get('planning_scene/floor.stl'))
    cm = CollisionMesh(mesh, 'floor')
    client.add_collision_mesh(cm)
    
    mesh.transform(Translation.from_vector([1,1,1]))
    cm = CollisionMesh(mesh, 'floor_translated')
    client.add_collision_mesh(cm)
```

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
