### PR TITLE
Adds unordered_disabled_collisions to PyBulletClient and RobotSemantics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,14 +12,15 @@ Unreleased
 
 **Added**
 * Added ``PoseArray``, ``MultiArrayDimension``, ``MultiArrayLayout``, ``Int8MultiArray``, ``Float32MultiArray``, ``Int32`` to ``compas_fab.backends.ros.messages``
+* Added ``unordered_disabled_collisions`` attribute to ``PyBulletClient`` and ``RobotSemantics``
 
 **Changed**
 
 **Fixed**
 
-* Fixed `UnsupportedOperation` error when using `PybulletClient` in Jupyter notebook (raised by `redirect_stdout`)
-* Fixed `JointTrajectoryPoint.from_data` to be backward-compatible with JSON data generated before `compas_fab 0.18`
-* Fixed `JointTrajectory.from_data` to be backward-compatible with JSON data generated before `compas_fab 0.17`
+* Fixed ``UnsupportedOperation`` error when using ``PyBulletClient`` in Jupyter notebook (raised by ``redirect_stdout``)
+* Fixed ``JointTrajectoryPoint.from_data`` to be backward-compatible with JSON data generated before ``compas_fab`` 0.18
+* Fixed ``JointTrajectory.from_data`` to be backward-compatible with JSON data generated before ``compas_fab`` 0.17
 
 **Deprecated**
 

--- a/src/compas_fab/backends/pybullet/client.py
+++ b/src/compas_fab/backends/pybullet/client.py
@@ -153,6 +153,10 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         self._cache_dir.cleanup()
         self.disconnect()
 
+    @property
+    def unordered_disabled_collisions(self):
+        return {frozenset(pair) for pair in self.disabled_collisions}
+
     def step_simulation(self):
         """By default, the physics server will not step the simulation,
         unless you explicitly send a ``step_simulation`` command.  This
@@ -464,7 +468,7 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         link_names = [link.name for link in cached_robot.iter_links() if link.collision]
         # check for collisions between robot links
         for link_1_name, link_2_name in combinations(link_names, 2):
-            if {link_1_name, link_2_name} in self.disabled_collisions:
+            if {link_1_name, link_2_name} in self.unordered_disabled_collisions:
                 continue
             link_1_id = self._get_link_id_by_name(link_1_name, cached_robot)
             link_2_id = self._get_link_id_by_name(link_2_name, cached_robot)

--- a/src/compas_fab/robots/semantics.py
+++ b/src/compas_fab/robots/semantics.py
@@ -39,6 +39,10 @@ class RobotSemantics(object):
     def group_names(self):
         return list(self.groups.keys())
 
+    @property
+    def unordered_disabled_collisions(self):
+        return {frozenset(pair) for pair in self.disabled_collisions}
+
     @classmethod
     def from_srdf_file(cls, file, robot_model):
         """Create an instance of semantics based on an SRDF file path or file-like object."""


### PR DESCRIPTION
Addresses #318 

Following the discussion in the above mentioned issue, I've added a new property `unordered_disabled_collisions` which is a set of frozensets with the same data as in the usual `disabled_collisions` which is a set of tuples.  This is backward compatible and keeps the existing code clean.  Now `pybullet_client.disabled_collisions = semantics.disabled_collisions` will behave as desired.  I didn't add a more broad function to add semantic data to the pybullet client because currently group support in pybullet is a bit hacky and I don't want make it seem otherwise ;)

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
