### PR TITLE
yield uniform types in inverse_kinematics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Unreleased
 
 **Changed**
 
+* Changed the backend feature `InverseKinematics.inverse_kinematics` to be a generator
+* Standardized the yielded type of `InverseKinematics.inverse_kinematics` across the PyBullet, MoveIt and V-REP planners
+
 **Fixed**
 
 * Fixed ``UnsupportedOperation`` error when using ``PyBulletClient`` in Jupyter notebook (raised by ``redirect_stdout``)

--- a/docs/examples/04_backends_vrep/01_simulation_with_vrep.rst
+++ b/docs/examples/04_backends_vrep/01_simulation_with_vrep.rst
@@ -98,7 +98,7 @@ that there is at least one valid configuration to reach the goal pose.
         options = {
             'num_joints': len(robot.get_configurable_joints()),
         }
-        configs = client.inverse_kinematics(robot, goal_pose, group=group, options=options)
+        configs = list(client.inverse_kinematics(robot, goal_pose, group=group, options=options))
 
         assert len(configs) > 0, 'No IK solution found'
         print('Found valid configuration: ', str(configs[-1]))

--- a/src/compas_fab/backends/interfaces/backend_features.py
+++ b/src/compas_fab/backends/interfaces/backend_features.py
@@ -55,6 +55,8 @@ class InverseKinematics(object):
     def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
         """Calculate the robot's inverse kinematic for a given frame.
 
+        Note that unlike other backend features, `inverse_kinematics` produces a generator.
+
         Parameters
         ----------
         robot : :class:`compas_fab.robots.Robot`
@@ -68,7 +70,7 @@ class InverseKinematics(object):
             Dictionary containing kwargs for arguments specific to
             the client being queried.
 
-        Returns
+        Yields
         -------
         :obj:`tuple` of :obj:`list`
             A tuple of 2 elements containing a list of joint positions and a list of matching joint names.

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -53,7 +53,7 @@ class PyBulletInverseKinematics(InverseKinematics):
               robot's joint limits will be ignored in the calculation.  Defaults to
               ``True``.
 
-        Returns
+        Yields
         -------
         :obj:`tuple` of :obj:`list`
             A tuple of 2 elements containing a list of joint positions and a list of matching joint names.
@@ -126,7 +126,7 @@ class PyBulletInverseKinematics(InverseKinematics):
         if not joint_positions:
             raise InverseKinematicsError()
 
-        return joint_positions, joint_names
+        yield joint_positions, joint_names
 
     def _get_rest_poses(self, joint_names, configuration):
         name_value_map = {configuration.joint_names[i]: configuration.joint_values[i] for i in range(len(configuration.joint_names))}

--- a/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
@@ -75,7 +75,7 @@ class MoveItInverseKinematics(InverseKinematics):
         compas_fab.backends.exceptions.BackendError
             If no configuration can be found.
 
-        Returns
+        Yields
         -------
         :obj:`tuple` of :obj:`list`
             A tuple of 2 elements containing a list of joint positions and a list of matching joint names.
@@ -91,7 +91,7 @@ class MoveItInverseKinematics(InverseKinematics):
         # Use base_link or fallback to model's root link
         options['base_link'] = options.get('base_link', robot.model.root.name)
 
-        return await_callback(self.inverse_kinematics_async, **kwargs)
+        yield await_callback(self.inverse_kinematics_async, **kwargs)
 
     def inverse_kinematics_async(self, callback, errback,
                                  frame_WCF, start_configuration=None, group=None, options=None):

--- a/src/compas_fab/backends/vrep/backend_features/vrep_inverse_kinematics.py
+++ b/src/compas_fab/backends/vrep/backend_features/vrep_inverse_kinematics.py
@@ -40,9 +40,9 @@ class VrepInverseKinematics(InverseKinematics):
                   to retry infinitely.
                 - ``"max_results"``: (:obj:`int`) Maximum number of result states to return.
 
-        Returns:
-            list: List of :class:`Configuration` objects representing
-            the collision-free configuration for the ``goal_frame``.
+        Yields:
+            :obj:`tuple` of :obj:`list`
+                A tuple of 2 elements containing a list of joint positions and a list of matching joint names.
         """
         options = options or {}
         num_joints = options['num_joints']
@@ -59,5 +59,7 @@ class VrepInverseKinematics(InverseKinematics):
 
         states = self.client.find_raw_robot_states(group, frame_to_vrep_pose(frame_WCF, self.client.scale), gantry_joint_limits, arm_joint_limits, max_trials, max_results)
 
-        return [config_from_vrep(states[i:i + num_joints], self.client.scale)
-                for i in range(0, len(states), num_joints)]
+        joint_names = robot.get_configurable_joint_names()
+
+        for i in range(0, len(states), num_joints):
+            yield config_from_vrep(states[i: i+num_joints], self.client.scale).joint_values, joint_names

--- a/src/compas_fab/backends/vrep/client.py
+++ b/src/compas_fab/backends/vrep/client.py
@@ -192,7 +192,9 @@ class VrepClient(ClientInterface):
             'num_joints': joints,
             'metric_values': [0.] * joints,
         }
-        config = self.inverse_kinematics(robot, frame, group=robot.model.attr['index'], options=options)[-1]
+        joint_values, joint_names = list(self.inverse_kinematics(robot, frame, group=robot.model.attr['index'], options=options))[-1]
+
+        config = config_from_vrep(joint_values, self.scale)
 
         if not config:
             raise ValueError('Cannot find a valid config for the given pose')

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1173,11 +1173,11 @@ class Robot(object):
         options['attached_collision_meshes'] = attached_collision_meshes
 
         # The returned joint names might be more than the requested ones if there are passive joints present
-        joint_positions, joint_names = self.client.inverse_kinematics(self,
-                                                                      frame_WCF_scaled,
-                                                                      start_configuration_scaled,
-                                                                      group,
-                                                                      options)
+        joint_positions, joint_names = next(self.client.inverse_kinematics(self,
+                                                                           frame_WCF_scaled,
+                                                                           start_configuration_scaled,
+                                                                           group,
+                                                                           options))
         if return_full_configuration:
             # build configuration including passive joints, but no sorting
             joint_types = self.get_joint_types_by_names(joint_names)


### PR DESCRIPTION
Here I've changed the ik backend features to yield the results rather than return them.

One point that is up for discussion still is that `robot.inverse_kinematics` returns a configuration while `client.inverse_kinematics` generates tuples of joint value, joint name pairs.  This is confusing.  

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
