### PR TITLE
Make Robot.inverse_kinematics use the last generator if called repeatedly with same arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,8 +18,8 @@ Unreleased
 
 **Changed**
 
-* Changed the backend feature `InverseKinematics.inverse_kinematics` to be a generator
-* Standardized the yielded type of `InverseKinematics.inverse_kinematics` across the PyBullet, MoveIt and V-REP planners
+* Changed the backend feature ``InverseKinematics.inverse_kinematics`` to be a generator. As a consequence of this, ``ClientInterface.inverse_kinematics`` and ``PlannerInterface.inverse_kinematics`` have changed to generators as well.
+* Standardized the yielded type of ``InverseKinematics.inverse_kinematics`` across the PyBullet, MoveIt and V-REP planners
 
 **Fixed**
 


### PR DESCRIPTION
PR of a PR! As discussed, this suggestion was too big to add as PR comments, so, here it is as a PR of a PR. The idea is make `inverse_kinematics` in `Robot` behave like a generator if called multiple times with same arguments, but without actually becoming a generator, just keeping track of the last one used internally.