### PR TITLE
Fix the ghuser component build task fetch GHIO lib from NuGet

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -214,7 +214,7 @@ def prepare_changelog(ctx):
 
 
 @task(help={
-      'gh_io_folder': 'Folder where GH_IO.dll is located. Usually Rhino installation folder.',
+      'gh_io_folder': 'Folder where GH_IO.dll is located. If not specified, it will try to download from NuGet.',
       'ironpython': 'Command for running the IronPython executable. Defaults to `ipy`.'})
 def build_ghuser_components(ctx, gh_io_folder=None, ironpython=None):
     """Build Grasshopper user objects from source"""
@@ -226,8 +226,9 @@ def build_ghuser_components(ctx, gh_io_folder=None, ironpython=None):
             ctx.run('git clone https://github.com/compas-dev/compas-actions.ghpython_components.git {}'.format(action_dir))
 
             if not gh_io_folder:
+                gh_io_folder = 'temp'
                 import compas_ghpython
-                gh_io_folder = compas_ghpython.get_grasshopper_plugin_path('6.0')
+                compas_ghpython.fetch_ghio_lib(gh_io_folder)
 
             if not ironpython:
                 ironpython = 'ipy'


### PR DESCRIPTION
Fix the local build ghuser task to match what compas core does now. See https://github.com/compas-dev/compas/pull/949

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
