### PR TITLE
Default to hide robot wires

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Unreleased
 
 **Changed**
 
+* Changed default wire visibility to hidden in some GH components for cleaner Grasshopper files.
+
 **Fixed**
 
 **Deprecated**

--- a/src/compas_fab/ghpython/components/Cf_ConstraintsFromPlane/metadata.json
+++ b/src/compas_fab/ghpython/components/Cf_ConstraintsFromPlane/metadata.json
@@ -11,7 +11,8 @@
         "inputParameters": [
             {
                 "name": "robot",
-                "description": "The robot."
+                "description": "The robot.",
+                "wireDisplay": "hidden"
             },
             {
                 "name": "plane",

--- a/src/compas_fab/ghpython/components/Cf_InverseKinematics/metadata.json
+++ b/src/compas_fab/ghpython/components/Cf_InverseKinematics/metadata.json
@@ -11,7 +11,8 @@
         "inputParameters": [
             {
                 "name": "robot",
-                "description": "The robot."
+                "description": "The robot.",
+                "wireDisplay": "hidden"
             },
             {
                 "name": "plane",

--- a/src/compas_fab/ghpython/components/Cf_PlanCartesianMotion/metadata.json
+++ b/src/compas_fab/ghpython/components/Cf_PlanCartesianMotion/metadata.json
@@ -11,7 +11,8 @@
         "inputParameters": [
             {
                 "name": "robot",
-                "description": "The robot."
+                "description": "The robot.",
+                "wireDisplay": "hidden"
             },
             {
                 "name": "planes",

--- a/src/compas_fab/ghpython/components/Cf_PlanMotion/metadata.json
+++ b/src/compas_fab/ghpython/components/Cf_PlanMotion/metadata.json
@@ -11,7 +11,8 @@
         "inputParameters": [
             {
                 "name": "robot",
-                "description": "The robot."
+                "description": "The robot.",
+                "wireDisplay": "hidden"
             },
             {
                 "name": "goal_constraints",

--- a/src/compas_fab/ghpython/components/Cf_PlanningScene/metadata.json
+++ b/src/compas_fab/ghpython/components/Cf_PlanningScene/metadata.json
@@ -11,7 +11,8 @@
         "inputParameters": [
             {
                 "name": "robot",
-                "description": "The robot."
+                "description": "The robot.",
+                "wireDisplay": "hidden"
             }
         ],
         "outputParameters": [

--- a/src/compas_fab/ghpython/components/Cf_VisualizeRobot/metadata.json
+++ b/src/compas_fab/ghpython/components/Cf_VisualizeRobot/metadata.json
@@ -11,7 +11,8 @@
         "inputParameters": [
             {
                 "name": "robot",
-                "description": "The robot."
+                "description": "The robot.",
+                "wireDisplay": "hidden"
             },
             {
                 "name": "group",

--- a/src/compas_fab/ghpython/components/Cf_VisualizeTrajectory/metadata.json
+++ b/src/compas_fab/ghpython/components/Cf_VisualizeTrajectory/metadata.json
@@ -11,7 +11,8 @@
         "inputParameters": [
             {
                 "name": "robot",
-                "description": "The robot."
+                "description": "The robot.",
+                "wireDisplay": "hidden"
             },
             {
                 "name": "group",


### PR DESCRIPTION
I usually spend more-than-desirable time during workshops cleaning up Grasshopper examples because the wires connecting to `robot` are such a mess. So, instead of that, we could default to `hidden`.


### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
