### PR TITLE
Update 09_ros_create_urdf_ur10_on_tower.rst

### DIFF
--- a/docs/examples/03_backends_ros/09_ros_create_urdf_ur10_on_tower.rst
+++ b/docs/examples/03_backends_ros/09_ros_create_urdf_ur10_on_tower.rst
@@ -70,7 +70,7 @@ Optionally, modify ``email`` and ``licence``, ``version`` tags.
 
 Then create 4(+2) folders: ``launch``, ``rviz``, ``urdf`` and ``meshes`` (with visual and collision folders)::
 
-  mkdir ~/robotic_setups/src/{launch,rviz,urdf,meshes/visual,meshes/collision}
+  mkdir ~/robotic_setups/src/{launch,rviz,urdf,meshes,meshes/visual,meshes/collision}
 
 Copy your meshes into ``meshes/visual`` and ``meshes/collision``.
 


### PR DESCRIPTION
I am getting the error "mkdir: cannot create directory ‘./src/meshes/visual’: No such file or directory"
Adding 'meshes' to be created before the subfolders solves that issue to me.

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)
