### PR TITLE
fix: pose of collision meshes was ignored in ROS Noetic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Unreleased
 * Fixed PyBullet loading of meshes.
 * Fixed missing flag in reset planning scene call.
 * Fixed issue on cartesian and kinematic planning when model contains passive joints.
+* Fixed pose of collision mesh in ROS Noetic being ignored.
 
 **Deprecated**
 

--- a/src/compas_fab/backends/ros/backend_features/move_it_add_attached_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_add_attached_collision_mesh.py
@@ -55,5 +55,5 @@ class MoveItAddAttachedCollisionMesh(AddAttachedCollisionMesh):
         aco.object.operation = CollisionObject.ADD
         robot_state = RobotState(attached_collision_objects=[aco], is_diff=True)
         scene = PlanningScene(robot_state=robot_state, is_diff=True)
-        request = dict(scene=scene)
+        request = scene.to_request(self.ros_client.ros_distro)
         self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_add_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_add_collision_mesh.py
@@ -53,5 +53,5 @@ class MoveItAddCollisionMesh(AddCollisionMesh):
         co.operation = CollisionObject.ADD
         world = PlanningSceneWorld(collision_objects=[co])
         scene = PlanningScene(world=world, is_diff=True)
-        request = dict(scene=scene)
+        request = scene.to_request(self.ros_client.ros_distro)
         self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_append_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_append_collision_mesh.py
@@ -53,5 +53,5 @@ class MoveItAppendCollisionMesh(AppendCollisionMesh):
         co.operation = CollisionObject.APPEND
         world = PlanningSceneWorld(collision_objects=[co])
         scene = PlanningScene(world=world, is_diff=True)
-        request = dict(scene=scene)
+        request = scene.to_request(self.ros_client.ros_distro)
         self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_remove_attached_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_remove_attached_collision_mesh.py
@@ -55,5 +55,5 @@ class MoveItRemoveAttachedCollisionMesh(RemoveAttachedCollisionMesh):
         aco.object.operation = CollisionObject.REMOVE
         robot_state = RobotState(attached_collision_objects=[aco], is_diff=True)
         scene = PlanningScene(robot_state=robot_state, is_diff=True)
-        request = dict(scene=scene)
+        request = scene.to_request(self.ros_client.ros_distro)
         self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_remove_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_remove_collision_mesh.py
@@ -54,5 +54,5 @@ class MoveItRemoveCollisionMesh(RemoveCollisionMesh):
         co.operation = CollisionObject.REMOVE
         world = PlanningSceneWorld(collision_objects=[co])
         scene = PlanningScene(world=world, is_diff=True)
-        request = dict(scene=scene)
+        request = scene.to_request(self.ros_client.ros_distro)
         self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_reset_planning_scene.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_reset_planning_scene.py
@@ -51,5 +51,5 @@ class MoveItResetPlanningScene(ResetPlanningScene):
             collision_object.object['operation'] = CollisionObject.REMOVE
         scene.is_diff = True
         scene.robot_state.is_diff = True
-        request = dict(scene=scene)
+        request = scene.to_request(self.ros_client.ros_distro)
         self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)

--- a/src/compas_fab/backends/ros/client.py
+++ b/src/compas_fab/backends/ros/client.py
@@ -157,7 +157,7 @@ class RosClient(Ros, ClientInterface):
     def ros_distro(self):
         """Retrieves the ROS version to which the client is connected (eg. kinetic)"""
         if not self._ros_distro:
-            self._ros_distro = Param(self, '/rosdistro').get(timeout=1)
+            self._ros_distro = Param(self, '/rosdistro').get(timeout=1).strip()
 
         return self._ros_distro
 

--- a/src/compas_fab/backends/ros/messages/moveit_msgs.py
+++ b/src/compas_fab/backends/ros/messages/moveit_msgs.py
@@ -7,6 +7,7 @@ from compas_fab.backends.ros.messages.geometry_msgs import Quaternion
 from compas_fab.backends.ros.messages.geometry_msgs import Vector3
 from compas_fab.backends.ros.messages.object_recognition_msgs import ObjectType
 from compas_fab.backends.ros.messages.octomap_msgs import OctomapWithPose
+from compas_fab.backends.ros.messages.ros_releases import RosDistro
 from compas_fab.backends.ros.messages.sensor_msgs import JointState
 from compas_fab.backends.ros.messages.sensor_msgs import MultiDOFJointState
 from compas_fab.backends.ros.messages.shape_msgs import Mesh
@@ -38,6 +39,8 @@ class CollisionObject(ROSmsg):
         self.header = header or Header()  # a header, used for interpreting the poses
         self.id = id  # the id of the object (name used in MoveIt)
         self.type = type or ObjectType()  # The object type in a database of known objects
+        self.pose = pose or Pose()  # currently not actively used in FAB, but needed to be present otherwise ROS Noetic complains about empty quaternion
+
         # solid geometric primitives
         self.primitives = primitives or []
         self.primitive_poses = primitive_poses or []
@@ -59,6 +62,7 @@ class CollisionObject(ROSmsg):
         kwargs['id'] = collision_mesh.id
         kwargs['meshes'] = [Mesh.from_mesh(collision_mesh.mesh)]
         kwargs['mesh_poses'] = [Pose.from_frame(collision_mesh.frame)]
+        kwargs['pose'] = Pose()
 
         return cls(**kwargs)
 
@@ -69,6 +73,7 @@ class CollisionObject(ROSmsg):
         kwargs['header'] = Header.from_msg(msg['header'])
         kwargs['id'] = msg['id']
         kwargs['type'] = ObjectType.from_msg(msg['type'])
+        kwargs['pose'] = Pose.from_msg(msg['pose']) if 'pose' in msg else Pose()
 
         kwargs['primitives'] = [SolidPrimitive.from_msg(i) for i in msg['primitives']]
         kwargs['primitive_poses'] = [Pose.from_msg(i) for i in msg['primitive_poses']]
@@ -554,6 +559,20 @@ class PlanningScene(ROSmsg):
         self.object_colors = object_colors or []                    # moveit_msgs/ObjectColor[]
         self.world = world or PlanningSceneWorld()                  # moveit_msgs/PlanningSceneWorld
         self.is_diff = is_diff                                      # bool
+
+    def to_request(self, ros_distro):
+        self.filter_fields_for_distro(ros_distro)
+        return dict(scene=self)
+
+    def filter_fields_for_distro(self, ros_distro):
+        """To maintain backwards compatibility with older ROS distros,
+        we need to make sure newly added fields are removed from the request."""
+        # Remove the field `pose` for distros older than NOETIC
+        if ros_distro in (RosDistro.KINETIC, RosDistro.MELODIC):
+            for aco in self.robot_state.attached_collision_objects:
+                del aco.object.pose
+            for co in self.world.collision_objects:
+                del co.pose
 
     @classmethod
     def from_msg(cls, msg):


### PR DESCRIPTION
The lack of the `pose` field in ROS noetic caused it to ignore the frame of the collision meshes (it complains about empty quaternions)

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
