### PR TITLE
Fix uninstall of GH components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Unreleased
 
 **Fixed**
 
+* Fixed uninstall process not removing GH components.
+
 **Deprecated**
 
 **Removed**

--- a/src/compas_fab/ghpython/components/install.py
+++ b/src/compas_fab/ghpython/components/install.py
@@ -61,7 +61,7 @@ def uninstall():
 
         dstdir = get_grasshopper_userobjects_path(version)
         srcdir = os.path.dirname(__file__)
-        userobjects = glob.glob(os.path.join(srcdir, '*.ghuser'))
+        userobjects = glob.glob(os.path.join(srcdir, 'ghuser', '*.ghuser'))
 
         symlinks = []
         for src in userobjects:


### PR DESCRIPTION
The uninstaller was pointing to the wrong directory, so it doesn't uninstall anything. Now it should be correct.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
