### PR TITLE
added support in Robot for attaching tools to multiple planning groups

### DIFF
--- a/src/compas_fab/ghpython/components/Cf_AttachTool/code.py
+++ b/src/compas_fab/ghpython/components/Cf_AttachTool/code.py
@@ -13,7 +13,7 @@ from compas_fab.robots import Tool
 
 
 class AttachToolComponent(component):
-    def RunScript(self, robot, visual_mesh, collision_mesh, tcf_plane):
+    def RunScript(self, robot, visual_mesh, collision_mesh, tcf_plane, planning_group_name=None):
         if robot and robot.client and robot.client.is_connected and visual_mesh:
             if not collision_mesh:
                 collision_mesh = visual_mesh
@@ -28,7 +28,7 @@ class AttachToolComponent(component):
             tool = Tool(c_visual_mesh, frame, c_collision_mesh)
 
             scene = PlanningScene(robot)
-            robot.attach_tool(tool)
+            robot.attach_tool(tool, planning_group_name)
             scene.add_attached_tool()
 
         return robot

--- a/src/compas_fab/robots/planning_scene.py
+++ b/src/compas_fab/robots/planning_scene.py
@@ -456,20 +456,24 @@ class PlanningScene(object):
         acm = AttachedCollisionMesh(collision_mesh, ee_link_name, touch_links)
         self.add_attached_collision_mesh(acm)
 
-    def add_attached_tool(self, tool=None):
+    def add_attached_tool(self, tool=None, group=None):
         """Add the robot's attached tool to the planning scene if tool is set."""
         self.ensure_client()
         if tool:
-            self.robot.attach_tool(tool)
-        if self.robot.attached_tool:
-            for acm in self.robot.attached_tool.attached_collision_meshes:
-                self.add_attached_collision_mesh(acm)
+            self.robot.attach_tool(tool, group)
+
+        # robot has 0 or more tools, each tool has a list of attached meshes
+        for tool_mesh_list in self.robot.get_attached_tool_collision_meshes():
+            for attached_collision_mesh in tool_mesh_list:
+                self.add_attached_collision_mesh(attached_collision_mesh)
 
     def remove_attached_tool(self):
         """Remove the robot's attached tool from the planning scene."""
         self.ensure_client()
-        if self.robot.attached_tool:
-            for acm in self.robot.attached_tool.attached_collision_meshes:
-                self.remove_attached_collision_mesh(acm.collision_mesh.id)
-                self.remove_collision_mesh(acm.collision_mesh.id)
+
+        # robot has 0 or more tools, each tool has a list of attached meshes
+        for tool_mesh_list in self.robot.get_attached_tool_collision_meshes():
+            for attached_collision_mesh in tool_mesh_list:
+                self.remove_attached_collision_mesh(attached_collision_mesh.collision_mesh.id)
+                self.remove_collision_mesh(attached_collision_mesh.collision_mesh.id)
         self.robot.detach_tool()


### PR DESCRIPTION
Added/fixed support for multiple tools per robot, one in each planning group.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
