### PR TITLE
added some missing information to GH and v-rep docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Unreleased
 
 **Added**
 
+* Added some missing information to GH and V-REP docs.
+
 **Changed**
 
 **Fixed**

--- a/docs/backends/vrep.rst
+++ b/docs/backends/vrep.rst
@@ -31,6 +31,12 @@ container with the following commands on the command prompt::
     to `download V-REP <https://www.coppeliarobotics.com/downloads>`_ and
     install it as a normal application.
 
+.. note::
+
+    `vrep.py` uses `remoteApi <https://www.coppeliarobotics.com/helpFiles/en/remoteApiOverview.htm>`_ to communicate with the simulator's instance. For this purpose, the `remoteApi`
+    shared library is expected in the same path as this module. The library can be obtained from the installation path
+    of the simulator and has to be copied or symlinked to `compas_fab/backends/vrep/remote_api/`.
+
 .. _Docker: https://www.docker.com/
 .. _Docker Hub: https://hub.docker.com/u/gramaziokohler/vrep/
 

--- a/docs/developer/grasshopper.rst
+++ b/docs/developer/grasshopper.rst
@@ -11,7 +11,7 @@ Grasshopper user objects need to be built using `COMPAS Github Action componenti
 
    .. code-block:: bash
 
-        invoke build-ghuser-components <path_to_ghio.dll>
+        invoke build-ghuser-components --gh-io-folder=<path_to_ghio.dll>
 
 3. Install them on Rhino/Grasshopper as usual:
 


### PR DESCRIPTION
Added some missing information to Grasshopper and V-REP doc pages.

- [x] Other (e.g. doc update, configuration, etc)
