### PR TITLE
Planning scene viz

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,11 @@ Unreleased
 
 **Added**
 
+* Added support for attached and non-attached collision mesh visualization to the ``Robot Visualize`` GH component.
+
 **Changed**
+
+* Changed behavior of ``Attach Tool`` GH component to only attach the tool but not add it to the planning scene state.
 
 **Fixed**
 

--- a/docs/examples/03_backends_ros/02_robot_models.rst
+++ b/docs/examples/03_backends_ros/02_robot_models.rst
@@ -5,7 +5,7 @@ Robots in ROS
 .. note::
 
     The following examples use the `ROS <https://www.ros.org/>`_ backend
-    and the MoveI! planner for UR5 robots. Before running them, please
+    and the MoveIt! planner for UR5 robots. Before running them, please
     make sure you have the :ref:`ROS backend <ros_backend>` correctly
     configured and the :ref:`UR5 Demo <ros_bundles_list>` started.
 

--- a/docs/examples/03_backends_ros/03_forward_and_inverse_kinematics.rst
+++ b/docs/examples/03_backends_ros/03_forward_and_inverse_kinematics.rst
@@ -9,7 +9,7 @@ Forward and inverse kinematics
 .. note::
 
     The following examples use the `ROS <https://www.ros.org/>`_ backend
-    and the MoveI! planner for UR5 robots. Before running them, please
+    and the MoveIt! planner for UR5 robots. Before running them, please
     make sure you have the :ref:`ROS backend <ros_backend>` correctly
     configured and the :ref:`UR5 Demo <ros_bundles_list>` started.
 

--- a/docs/examples/03_backends_ros/04_plan_motion.rst
+++ b/docs/examples/03_backends_ros/04_plan_motion.rst
@@ -5,7 +5,7 @@ Plan motion
 .. note::
 
     The following examples use the `ROS <https://www.ros.org/>`_ backend
-    and the MoveI! planner for UR5 robots. Before running them, please
+    and the MoveIt! planner for UR5 robots. Before running them, please
     make sure you have the :ref:`ROS backend <ros_backend>` correctly
     configured and the :ref:`UR5 Demo <ros_bundles_list>` started.
 

--- a/docs/examples/03_backends_ros/05_collision_objects.rst
+++ b/docs/examples/03_backends_ros/05_collision_objects.rst
@@ -5,7 +5,7 @@ Planning scene and collision objects
 .. note::
 
     The following examples use the `ROS <https://www.ros.org/>`_ backend
-    and the MoveI! planner for UR5 robots. Before running them, please
+    and the MoveIt! planner for UR5 robots. Before running them, please
     make sure you have the :ref:`ROS backend <ros_backend>` correctly
     configured and the :ref:`UR5 Demo <ros_bundles_list>` started.
 

--- a/src/compas_fab/backends/kinematics/solvers/offset_wrist.py
+++ b/src/compas_fab/backends/kinematics/solvers/offset_wrist.py
@@ -35,32 +35,47 @@ def forward_kinematics_offset_wrist(joint_values, params):
     s23, c23 = sin(q23), cos(q23)
     s234, c234 = sin(q234), cos(q234)
 
-    T = [0. for _ in range(4*4)]
+    T = [0.0 for _ in range(4 * 4)]
 
-    T[0] = c234*c1*s5 - c5*s1
-    T[1] = c6*(s1*s5 + c234*c1*c5) - s234*c1*s6
-    T[2] = -s6*(s1*s5 + c234*c1*c5) - s234*c1*c6
-    T[3] = d6*c234*c1*s5 - a3*c23*c1 - a2 * \
-        c1*c2 - d6*c5*s1 - d5*s234*c1 - d4*s1
-    T[4] = c1*c5 + c234*s1*s5
-    T[5] = -c6*(c1*s5 - c234*c5*s1) - s234*s1*s6
-    T[6] = s6*(c1*s5 - c234*c5*s1) - s234*c6*s1
-    T[7] = d6*(c1*c5 + c234*s1*s5) + d4*c1 - \
-        a3*c23*s1 - a2*c2*s1 - d5*s234*s1
-    T[8] = -s234*s5
-    T[9] = -c234*s6 - s234*c5*c6
-    T[10] = s234*c5*s6 - c234*c6
-    T[11] = d1 + a3*s23 + a2*s2 - d5 * \
-        (c23*c4 - s23*s4) - d6*s5*(c23*s4 + s23*c4)
+    T[0] = c234 * c1 * s5 - c5 * s1
+    T[1] = c6 * (s1 * s5 + c234 * c1 * c5) - s234 * c1 * s6
+    T[2] = -s6 * (s1 * s5 + c234 * c1 * c5) - s234 * c1 * c6
+    T[3] = (
+        d6 * c234 * c1 * s5
+        - a3 * c23 * c1
+        - a2 * c1 * c2
+        - d6 * c5 * s1
+        - d5 * s234 * c1
+        - d4 * s1
+    )
+    T[4] = c1 * c5 + c234 * s1 * s5
+    T[5] = -c6 * (c1 * s5 - c234 * c5 * s1) - s234 * s1 * s6
+    T[6] = s6 * (c1 * s5 - c234 * c5 * s1) - s234 * c6 * s1
+    T[7] = (
+        d6 * (c1 * c5 + c234 * s1 * s5)
+        + d4 * c1
+        - a3 * c23 * s1
+        - a2 * c2 * s1
+        - d5 * s234 * s1
+    )
+    T[8] = -s234 * s5
+    T[9] = -c234 * s6 - s234 * c5 * c6
+    T[10] = s234 * c5 * s6 - c234 * c6
+    T[11] = (
+        d1
+        + a3 * s23
+        + a2 * s2
+        - d5 * (c23 * c4 - s23 * s4)
+        - d6 * s5 * (c23 * s4 + s23 * c4)
+    )
     T[15] = 1.0
 
-    frame = Frame((T[3], T[7], T[11]),
-                  (T[0], T[4], T[8]), (T[1], T[5], T[9]))
+    frame = Frame((T[3], T[7], T[11]), (T[0], T[4], T[8]), (T[1], T[5], T[9]))
 
     return frame
 
 
-def inverse_kinematics_offset_wrist(frame, params, q6_des=0.):
+def inverse_kinematics_offset_wrist(frame, params, q6_des=0.0):
     """Inverse kinematics function for offset wrist 6-axis robots.
 
     Parameters
@@ -101,57 +116,57 @@ def inverse_kinematics_offset_wrist(frame, params, q6_des=0.):
     A = d6 * T12 - T13
     B = d6 * T02 - T03
     R = A * A + B * B
-    if(fabs(A) < ZERO_THRESH):
+    if fabs(A) < ZERO_THRESH:
         div = 0.0
-        if(fabs(fabs(d4) - fabs(B)) < ZERO_THRESH):
+        if fabs(fabs(d4) - fabs(B)) < ZERO_THRESH:
             div = -sign(d4) * sign(B)
         else:
             div = -d4 / B
         arcsin = asin(div)
-        if(fabs(arcsin) < ZERO_THRESH):
+        if fabs(arcsin) < ZERO_THRESH:
             arcsin = 0.0
-        if(arcsin < 0.0):
+        if arcsin < 0.0:
             q1[0] = arcsin + 2.0 * pi
         else:
             q1[0] = arcsin
         q1[1] = pi - arcsin
 
-    elif(fabs(B) < ZERO_THRESH):
+    elif fabs(B) < ZERO_THRESH:
         div = 0.0
-        if(fabs(fabs(d4) - fabs(A)) < ZERO_THRESH):
-            div = sign(d4)*sign(A)
+        if fabs(fabs(d4) - fabs(A)) < ZERO_THRESH:
+            div = sign(d4) * sign(A)
         else:
             div = d4 / A
         arccos = acos(div)
         q1[0] = arccos
         q1[1] = 2.0 * pi - arccos
 
-    elif(d4 * d4 > R):
+    elif d4 * d4 > R:
         raise ValueError("No solutions")
     else:
         arccos = acos(d4 / sqrt(R))
         arctan = atan2(-B, A)
         pos = arccos + arctan
         neg = -arccos + arctan
-        if(fabs(pos) < ZERO_THRESH):
+        if fabs(pos) < ZERO_THRESH:
             pos = 0.0
-        if(fabs(neg) < ZERO_THRESH):
+        if fabs(neg) < ZERO_THRESH:
             neg = 0.0
-        if(pos >= 0.0):
+        if pos >= 0.0:
             q1[0] = pos
         else:
-            q1[0] = 2.0*pi + pos
-        if(neg >= 0.0):
+            q1[0] = 2.0 * pi + pos
+        if neg >= 0.0:
             q1[1] = neg
         else:
-            q1[1] = 2.0*pi + neg
+            q1[1] = 2.0 * pi + neg
 
     # wrist 2 joint (q5)
     q5 = [[0, 0], [0, 0]]
     for i in range(2):
-        numer = (T03 * sin(q1[i]) - T13*cos(q1[i]) - d4)
+        numer = T03 * sin(q1[i]) - T13 * cos(q1[i]) - d4
         div = 0.0
-        if(fabs(fabs(numer) - fabs(d6)) < ZERO_THRESH):
+        if fabs(fabs(numer) - fabs(d6)) < ZERO_THRESH:
             div = sign(numer) * sign(d6)
         else:
             div = numer / d6
@@ -168,62 +183,66 @@ def inverse_kinematics_offset_wrist(frame, params, q6_des=0.):
             q6 = 0.0
 
             # wrist 3 joint (q6)
-            if(fabs(s5) < ZERO_THRESH):
+            if fabs(s5) < ZERO_THRESH:
                 q6 = q6_des
             else:
-                q6 = atan2(sign(s5)*-(T01*s1 - T11*c1),
-                           sign(s5)*(T00*s1 - T10*c1))
-            if(fabs(q6) < ZERO_THRESH):
+                q6 = atan2(
+                    sign(s5) * -(T01 * s1 - T11 * c1), sign(s5) * (T00 * s1 - T10 * c1)
+                )
+            if fabs(q6) < ZERO_THRESH:
                 q6 = 0.0
-            if(q6 < 0.0):
-                q6 += 2.0*pi
+            if q6 < 0.0:
+                q6 += 2.0 * pi
 
             # RRR joints (q2,q3,q4)
             q2, q3, q4 = [0, 0], [0, 0], [0, 0]
 
             c6 = cos(q6)
             s6 = sin(q6)
-            x04x = -s5*(T02*c1 + T12*s1) - c5 * \
-                (s6*(T01*c1 + T11*s1) - c6*(T00*c1 + T10*s1))
-            x04y = c5*(T20*c6 - T21*s6) - T22*s5
-            p13x = d5*(s6*(T00*c1 + T10*s1) + c6*(T01*c1 + T11*s1)
-                       ) - d6*(T02*c1 + T12*s1) + T03*c1 + T13*s1
-            p13y = T23 - d1 - d6*T22 + d5*(T21*c6 + T20*s6)
+            x04x = -s5 * (T02 * c1 + T12 * s1) - c5 * (
+                s6 * (T01 * c1 + T11 * s1) - c6 * (T00 * c1 + T10 * s1)
+            )
+            x04y = c5 * (T20 * c6 - T21 * s6) - T22 * s5
+            p13x = (
+                d5 * (s6 * (T00 * c1 + T10 * s1) + c6 * (T01 * c1 + T11 * s1))
+                - d6 * (T02 * c1 + T12 * s1)
+                + T03 * c1
+                + T13 * s1
+            )
+            p13y = T23 - d1 - d6 * T22 + d5 * (T21 * c6 + T20 * s6)
 
-            c3 = (p13x*p13x + p13y*p13y - a2*a2 - a3*a3) / (2.0*a2*a3)
-            if(fabs(fabs(c3) - 1.0) < ZERO_THRESH):
+            c3 = (p13x * p13x + p13y * p13y - a2 * a2 - a3 * a3) / (2.0 * a2 * a3)
+            if fabs(fabs(c3) - 1.0) < ZERO_THRESH:
                 c3 = sign(c3)
-            elif(fabs(c3) > 1.0):
+            elif fabs(c3) > 1.0:
                 solutions.extend([None, None])
                 continue
 
             arccos = acos(c3)
             q3[0] = arccos
-            q3[1] = 2.0*pi - arccos
-            denom = a2*a2 + a3*a3 + 2*a2*a3*c3
+            q3[1] = 2.0 * pi - arccos
+            denom = a2 * a2 + a3 * a3 + 2 * a2 * a3 * c3
             s3 = sin(arccos)
-            A = (a2 + a3*c3)
-            B = a3*s3
-            q2[0] = atan2((A*p13y - B*p13x) / denom,
-                          (A*p13x + B*p13y) / denom)
-            q2[1] = atan2((A*p13y + B*p13x) / denom,
-                          (A*p13x - B*p13y) / denom)
-            c23_0 = cos(q2[0]+q3[0])
-            s23_0 = sin(q2[0]+q3[0])
-            c23_1 = cos(q2[1]+q3[1])
-            s23_1 = sin(q2[1]+q3[1])
-            q4[0] = atan2(c23_0*x04y - s23_0*x04x, x04x*c23_0 + x04y*s23_0)
-            q4[1] = atan2(c23_1*x04y - s23_1*x04x, x04x*c23_1 + x04y*s23_1)
+            A = a2 + a3 * c3
+            B = a3 * s3
+            q2[0] = atan2((A * p13y - B * p13x) / denom, (A * p13x + B * p13y) / denom)
+            q2[1] = atan2((A * p13y + B * p13x) / denom, (A * p13x - B * p13y) / denom)
+            c23_0 = cos(q2[0] + q3[0])
+            s23_0 = sin(q2[0] + q3[0])
+            c23_1 = cos(q2[1] + q3[1])
+            s23_1 = sin(q2[1] + q3[1])
+            q4[0] = atan2(c23_0 * x04y - s23_0 * x04x, x04x * c23_0 + x04y * s23_0)
+            q4[1] = atan2(c23_1 * x04y - s23_1 * x04x, x04x * c23_1 + x04y * s23_1)
 
             for k in range(2):
-                if(fabs(q2[k]) < ZERO_THRESH):
+                if fabs(q2[k]) < ZERO_THRESH:
                     q2[k] = 0.0
-                elif(q2[k] < 0.0):
-                    q2[k] += 2.0*pi
-                if(fabs(q4[k]) < ZERO_THRESH):
+                elif q2[k] < 0.0:
+                    q2[k] += 2.0 * pi
+                if fabs(q4[k]) < ZERO_THRESH:
                     q4[k] = 0.0
-                elif(q4[k] < 0.0):
-                    q4[k] += 2.0*pi
+                elif q4[k] < 0.0:
+                    q4[k] += 2.0 * pi
 
                 solutions.append([q1[i], q2[k], q3[k], q4[k], q5[i][j], q6])
 
@@ -232,8 +251,9 @@ def inverse_kinematics_offset_wrist(frame, params, q6_des=0.):
 
 if __name__ == "__main__":
     from compas.geometry import allclose
+
     params = [0.089159, -0.42500, -0.39225, 0.10915, 0.09465, 0.0823]  # ur5
     q = [0.2, 5.5, 1.4, 1.3, 2.6, 3.6]
     frame = forward_kinematics_offset_wrist(q, params)
     sol = inverse_kinematics_offset_wrist(frame, params)
-    assert(allclose(sol[0], q))
+    assert allclose(sol[0], q)

--- a/src/compas_fab/backends/kinematics/utils.py
+++ b/src/compas_fab/backends/kinematics/utils.py
@@ -17,13 +17,16 @@ def fit_within_bounds(angle, lower, upper):
         angle += 2 * math.pi
     while angle > upper:
         angle -= 2 * math.pi
-    assert(angle >= lower and angle <= upper), "Joint angle out of bounds."
+    assert angle >= lower and angle <= upper, "Joint angle out of bounds."
     return angle
 
 
 def joint_angles_to_configurations(robot, solutions, group=None):
     joint_names = robot.get_configurable_joint_names(group=group)
-    return [Configuration.from_revolute_values(q, joint_names=joint_names) if q else None for q in solutions]
+    return [
+        Configuration.from_revolute_values(q, joint_names=joint_names) if q else None
+        for q in solutions
+    ]
 
 
 def try_to_fit_configurations_between_bounds(robot, configurations, group=None):

--- a/src/compas_fab/ghpython/components/Cf_AttachTool/code.py
+++ b/src/compas_fab/ghpython/components/Cf_AttachTool/code.py
@@ -8,7 +8,6 @@ from compas_rhino.conversions import RhinoMesh
 from compas_rhino.conversions import plane_to_compas_frame
 
 from compas.geometry import Frame
-from compas_fab.robots import PlanningScene
 from compas_fab.robots import Tool
 
 
@@ -27,8 +26,6 @@ class AttachToolComponent(component):
                 frame = plane_to_compas_frame(tcf_plane)
             tool = Tool(c_visual_mesh, frame, c_collision_mesh)
 
-            scene = PlanningScene(robot)
             robot.attach_tool(tool, group)
-            scene.add_attached_tool()
 
         return robot

--- a/src/compas_fab/ghpython/components/Cf_VisualizeRobot/code.py
+++ b/src/compas_fab/ghpython/components/Cf_VisualizeRobot/code.py
@@ -3,18 +3,31 @@ Visualizes the robot.
 
 COMPAS FAB v0.26.0
 """
+from compas.artists import Artist
+from compas.geometry import Frame
 from compas.geometry import Transformation
-from compas_ghpython.artists import FrameArtist
-from compas_ghpython.artists import MeshArtist
+from compas_fab.robots import PlanningScene
 from ghpythonlib.componentbase import executingcomponent as component
 
 
 class RobotVisualize(component):
-    def RunScript(self, robot, group, configuration, attached_collision_meshes, show_visual, show_collision,
-                  show_frames, show_base_frame, show_end_effector_frame, show_acm):
+    def RunScript(
+        self,
+        robot,
+        group,
+        configuration,
+        show_visual,
+        show_collision,
+        show_frames,
+        show_base_frame,
+        show_end_effector_frame,
+        show_cm,
+        show_acm,
+    ):
 
         visual = None
         collision = None
+        collision_meshes = None
         attached_meshes = None
         frames = None
         base_frame = None
@@ -22,6 +35,8 @@ class RobotVisualize(component):
 
         if robot:
             show_visual = True if show_visual is None else show_visual
+            show_cm = True if show_cm is None else show_cm
+            show_acm = True if show_acm is None else show_acm
             configuration = configuration or robot.zero_configuration()
 
             robot.update(configuration, visual=show_visual, collision=show_collision)
@@ -35,27 +50,73 @@ class RobotVisualize(component):
 
             if show_base_frame:
                 base_compas_frame = compas_frames[0]
-                artist = FrameArtist(base_compas_frame)
+                artist = Artist(base_compas_frame)
                 base_frame = artist.draw()
 
             if show_end_effector_frame:
-                ee_compas_frame = robot.forward_kinematics(configuration, group, options=dict(solver='model'))
-                artist = FrameArtist(ee_compas_frame)
+                ee_compas_frame = robot.forward_kinematics(
+                    configuration, group, options=dict(solver="model")
+                )
+                artist = Artist(ee_compas_frame)
                 ee_frame = artist.draw()
 
             if show_frames:
                 frames = []
                 for compas_frame in compas_frames[1:]:
-                    artist = FrameArtist(compas_frame)
+                    artist = Artist(compas_frame)
                     frame = artist.draw()
                     frames.append(frame)
 
-            if show_acm:
-                attached_meshes = []
-                for acm in attached_collision_meshes:
-                    frame = robot.forward_kinematics(configuration, options=dict(solver='model', link=acm.link_name))
-                    T = Transformation.from_frame_to_frame(acm.collision_mesh.frame, frame)
-                    mesh = acm.collision_mesh.mesh.transformed(T)
-                    attached_meshes.append(MeshArtist(mesh).draw())
+            if show_cm or show_acm:
+                scene = PlanningScene(robot)
+                scene = robot.client.get_planning_scene()
 
-        return (visual, collision, attached_meshes, frames, base_frame, ee_frame)
+                collision_meshes = []
+                attached_meshes = []
+
+                if show_cm:
+                    for co in scene.world.collision_objects:
+                        header = co.header
+                        frame_id = header.frame_id
+                        cms = co.to_collision_meshes()
+
+                        for cm in cms:
+                            if cm.frame != Frame.worldXY():
+                                t = Transformation.from_frame(cm.frame)
+                                mesh = cm.mesh.transformed(t)
+                            else:
+                                mesh = cm.mesh
+
+                            collision_meshes.append(Artist(mesh).draw())
+
+                if show_acm:
+                    for aco in scene.robot_state.attached_collision_objects:
+                        for acm in aco.to_attached_collision_meshes():
+                            frame_id = aco.object.header.frame_id
+                            frame = robot.forward_kinematics(
+                                configuration, options=dict(link=frame_id)
+                            )
+                            t = Transformation.from_frame(frame)
+
+                            # Local CM frame
+                            if (
+                                acm.collision_mesh.frame
+                                and acm.collision_mesh.frame != Frame.worldXY()
+                            ):
+                                t = t * Transformation.from_frame(
+                                    acm.collision_mesh.frame
+                                )
+
+                            mesh = acm.collision_mesh.mesh.transformed(t)
+
+                            attached_meshes.append(Artist(mesh).draw())
+
+        return (
+            visual,
+            collision,
+            collision_meshes,
+            attached_meshes,
+            frames,
+            base_frame,
+            ee_frame,
+        )

--- a/src/compas_fab/ghpython/components/Cf_VisualizeRobot/metadata.json
+++ b/src/compas_fab/ghpython/components/Cf_VisualizeRobot/metadata.json
@@ -5,7 +5,6 @@
     "subcategory": "Display",
     "description": "Visualizes the robot.",
     "exposure": 2,
-
     "ghpython": {
         "isAdvancedMode": true,
         "iconDisplay": 2,
@@ -23,11 +22,6 @@
             {
                 "name": "configuration",
                 "description": "The robot's full configuration."
-            },
-            {
-                "name": "attached_collision_meshes",
-                "description": "A list of attached collision meshes.",
-                "scriptParamAccess": "list"
             },
             {
                 "name": "show_visual",
@@ -55,6 +49,11 @@
                 "typeHintID": "bool"
             },
             {
+                "name": "show_cm",
+                "description": "Whether or not to show the collision meshes (if any).",
+                "typeHintID": "bool"
+            },
+            {
                 "name": "show_acm",
                 "description": "Whether or not to show the attached collision meshes (if any).",
                 "typeHintID": "bool"
@@ -63,15 +62,19 @@
         "outputParameters": [
             {
                 "name": "visual",
-                "description": "The robot's visual Rhino meshes (if any)."
+                "description": "Rhino meshes of the robot's visual geometry (if any)."
             },
             {
                 "name": "collision",
-                "description": "The robot's collision Rhino meshes (if any)."
+                "description": "Rhino meshes of the robot's collision geometry (if any)."
+            },
+            {
+                "name": "collision_meshes",
+                "description": "Rhino meshes of the scene's collision meshes (if any)."
             },
             {
                 "name": "attached_meshes",
-                "description": "The attached collision Rhino meshes (if any)."
+                "description": "Rhino meshes of the scene's attached collision meshes (if any)."
             },
             {
                 "name": "frames",


### PR DESCRIPTION
This change (finally) adds supports for all the planning scene elements to be visualized with the default `Robot Visualize` component of Grasshopper. This means both attached and non-attached collision meshes will be retrieved and shown and there's no need to pass them to the component explicitly anymore.

Here's a quick screenshot showing the component in action with both an ACM and a CM:

![image](https://user-images.githubusercontent.com/933277/185412224-b5d13fce-28cf-4a6e-a46d-90287b256bbe.png)
![image](https://user-images.githubusercontent.com/933277/185412352-a70e22c0-18fd-46d9-b54e-17a0e375a7bf.png)

It also changes the behavior of the `Attach tool` component that was (needlessly) adding the tool meshes to the planning scene, but they can be an in-memory thing only.

And a bunch of typos as well.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
