### PR TITLE
Fix kinetic support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Unreleased
 **Fixed**
 
 * Fixed DH params for analytical IK solver of UR3e and UR10e.
+* Fixed Kinetic support on IK, FK, and motion planning calls.
 
 **Deprecated**
 

--- a/src/compas_fab/backends/ros/backend_features/move_it_forward_kinematics.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_forward_kinematics.py
@@ -87,6 +87,7 @@ class MoveItForwardKinematics(ForwardKinematics):
             name=configuration.joint_names, position=configuration.joint_values, header=header)
         robot_state = RobotState(
             joint_state, MultiDOFJointState(header=header))
+        robot_state.filter_fields_for_distro(self.ros_client.ros_distro)
 
         def convert_to_frame(response):
             callback(response.pose_stamped[0].pose.frame)

--- a/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
@@ -109,6 +109,7 @@ class MoveItInverseKinematics(InverseKinematics):
             name=start_configuration.joint_names, position=start_configuration.joint_values, header=header)
         start_state = RobotState(
             joint_state, MultiDOFJointState(header=header))
+        start_state.filter_fields_for_distro(self.ros_client.ros_distro)
 
         if options.get('attached_collision_meshes'):
             for acm in options['attached_collision_meshes']:

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_cartesian_motion.py
@@ -109,6 +109,7 @@ class MoveItPlanCartesianMotion(PlanCartesianMotion):
                                  name=start_configuration.joint_names,
                                  position=start_configuration.joint_values)
         start_state = RobotState(joint_state, MultiDOFJointState(header=header), is_diff=True)
+        start_state.filter_fields_for_distro(self.ros_client.ros_distro)
 
         if options.get('attached_collision_meshes'):
             for acm in options['attached_collision_meshes']:

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
@@ -114,6 +114,7 @@ class MoveItPlanMotion(PlanMotion):
             position=start_configuration.joint_values)
         start_state = RobotState(
             joint_state, MultiDOFJointState(header=header), is_diff=True)
+        start_state.filter_fields_for_distro(self.ros_client.ros_distro)
 
         if options.get('attached_collision_meshes'):
             for acm in options['attached_collision_meshes']:


### PR DESCRIPTION
This PR fixes support for ROS Kinetic when using FK, IK, plan cartesian and plan free-space motion. There was already a similar fix in place for all the planning scene operations, but it was not copied for the other backend features.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
