### PR TITLE
Re-advertise topic if the ros client has changed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Unreleased
 **Fixed**
 
 * Fixed DH params for analytical IK solver of UR3e and UR10e.
+* Fixed ``Publish to topic`` Grasshopper component when the ``ros_client`` has been replaced (eg. disconnected and reconnected).
 
 **Deprecated**
 

--- a/src/compas_fab/ghpython/components/Cf_RosTopicPublish/code.py
+++ b/src/compas_fab/ghpython/components/Cf_RosTopicPublish/code.py
@@ -25,8 +25,8 @@ class ROSTopicPublish(component):
         topic = st.get(key, None)
 
         if ros_client and ros_client.is_connected:
-            if not topic:
-                topic = Topic(ros_client, topic_name, topic_type)
+            if not topic or topic.ros != ros_client:
+                topic = Topic(ros_client, topic_name, topic_type, reconnect_on_close=False)
                 topic.advertise()
                 time.sleep(0.2)
 


### PR DESCRIPTION
If the `ros client` of a topic instance changes in Grasshopper, for example, if a new ROS connect component is connected to it, it needs to detect the instance is not the same and re-start the advertise operation before publishing.

This was found by @kunaalchadha and we tested the fix on his machine.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
