### PR TITLE
Moving most config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 180

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,15 @@ python_files = [
 addopts = "-ra --strict --doctest-glob=*.rst --tb=short"
 doctest_optionflags= "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE ALLOW_BYTES"
 filterwarnings = "ignore::DeprecationWarning"
+
+[tool.pydocstyle]
+convention = "numpy"
+add-ignore = ["D100"]
+
+[tool.isort]
+force_single_line = true
+line_length = 180
+known_first_party = "compas_fab"
+default_section = "THIRDPARTY"
+forced_separate = "test_compas_fab"
+skip = ["__init__.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,14 @@
 [tool.black]
 line-length = 180
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["src", "tests"]
+python_files = [
+    "test_*.py",
+    "*_test.py",
+    "tests.py"
+]
+addopts = "-ra --strict --doctest-glob=*.rst --tb=short"
+doctest_optionflags= "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE ALLOW_BYTES"
+filterwarnings = "ignore::DeprecationWarning"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ check-manifest>=0.36
 flake8
 autopep8
 pylint
-pytest>=4.6
+pytest>=6.0
 pytest_mock
 pytest-cov
 sybil

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 attrs>=19.3.0
-autopep8
+black
 bump2version>=1.0
 check-manifest>=0.36
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,16 @@
 attrs>=19.3.0
-sphinx_compas_theme>=0.9
-sphinx>=1.6
-invoke>=0.14
+autopep8
 bump2version>=1.0
 check-manifest>=0.36
 flake8
-autopep8
+invoke>=0.14
+isort
 pylint
-pytest>=6.0
 pytest_mock
 pytest-cov
+pytest>=6.0
+sphinx_compas_theme>=0.9
+sphinx>=1.6
 sybil
-isort
 twine
 -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,3 @@ exclude =
     dist,
     src/compas_fab/backends/vrep/remote_api/*,
     src/compas_fab/ghpython/path_planning.py
-
-[coverage:run]
-branch = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,24 +17,6 @@ exclude =
 convention = numpy
 add-ignore = D100
 
-[tool:pytest]
-testpaths = src tests
-norecursedirs =
-    migrations
-
-python_files =
-    test_*.py
-    *_test.py
-    tests.py
-addopts =
-    -ra
-    --strict
-    --doctest-glob=\*.rst
-    --tb=short
-doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE ALLOW_BYTES
-filterwarnings =
-    ignore::DeprecationWarning
-
 [isort]
 force_single_line = True
 line_length = 180

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,17 +13,5 @@ exclude =
     src/compas_fab/backends/vrep/remote_api/*,
     src/compas_fab/ghpython/path_planning.py
 
-[pydocstyle]
-convention = numpy
-add-ignore = D100
-
-[isort]
-force_single_line = True
-line_length = 180
-known_first_party = compas_fab
-default_section = THIRDPARTY
-forced_separate = test_compas_fab
-skip = migrations, __init__.py
-
 [coverage:run]
 branch = True

--- a/tasks.py
+++ b/tasks.py
@@ -178,17 +178,17 @@ def test(ctx, checks=False, doctest=False, codeblock=False, coverage=False):
         check(ctx)
 
     with chdir(BASE_FOLDER):
-        pytest_args = ['pytest']
+        pytest_args = ["pytest"]
         if doctest:
-            pytest_args.append('--doctest-modules')
+            pytest_args.append("--doctest-modules")
         if coverage:
-            pytest_args.append('--cov=compas_fab')
+            pytest_args.append("--cov-branch --cov=compas_fab")
 
         ctx.run(" ".join(pytest_args))
 
         # Using --doctest-modules together with docs as the testpaths goes bananas
         if codeblock:
-            ctx.run('pytest docs')
+            ctx.run("pytest docs")
 
 
 @task


### PR DESCRIPTION
First added the max line length to `black` settings in a new `pyproject.toml` and then moved most of the settings from `setup.cfg` to `pyproject.toml`. I tried to move `bdist_wheel` setting but it didn't seem to use it even though it is technically supported (I might have missed another setting to trigger that?), and then `flake8` would be the other one remaining, which doesn't officially support `pyproject.toml`, but we should replace with `black`.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
