### PR TITLE
Use attached tool's frame for all planning operations if any tool is attached

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,8 @@ Unreleased
 **Changed**
 
 * Changed behavior of ``Attach Tool`` GH component to only attach the tool but not add it to the planning scene state.
-* Duration class takes floats as ``sec`` variable
+* Duration class takes floats as ``sec`` variable.
+* Changed the behavior of ``forward_kinematics``, ``inverse_kinematics``, ``iter_inverse_kinematics``, ``plan_cartesian_motion`` and constraints construction methods (``orientation_constraint_from_frame``, ``position_constraint_from_frame``, ``constraints_from_frame``) in ``Robot`` class to use the frame of the attached tool if a tool is attached. This behavior can be reverted back (ie. only calculate T0CF) using the flag ``use_attached_tool_frame`` of all these methods.
 
 **Fixed**
 

--- a/docs/examples/06_backends_kinematics/files/04_cartesian_path_analytic_pybullet.py
+++ b/docs/examples/06_backends_kinematics/files/04_cartesian_path_analytic_pybullet.py
@@ -3,19 +3,21 @@ from compas.geometry import Frame
 
 from compas_fab.backends import AnalyticalPyBulletClient
 
-frames_WCF = [Frame((0.407, 0.073, 0.320), (0.922, 0.000, 0.388), (0.113, 0.956, -0.269)),
-              Frame((0.404, 0.057, 0.324), (0.919, 0.000, 0.394), (0.090, 0.974, -0.210)),
-              Frame((0.390, 0.064, 0.315), (0.891, 0.000, 0.454), (0.116, 0.967, -0.228)),
-              Frame((0.388, 0.079, 0.309), (0.881, 0.000, 0.473), (0.149, 0.949, -0.278)),
-              Frame((0.376, 0.087, 0.299), (0.850, 0.000, 0.528), (0.184, 0.937, -0.296))]
+frames_WCF = [
+    Frame((0.407, 0.073, 0.320), (0.922, 0.000, 0.388), (0.113, 0.956, -0.269)),
+    Frame((0.404, 0.057, 0.324), (0.919, 0.000, 0.394), (0.090, 0.974, -0.210)),
+    Frame((0.390, 0.064, 0.315), (0.891, 0.000, 0.454), (0.116, 0.967, -0.228)),
+    Frame((0.388, 0.079, 0.309), (0.881, 0.000, 0.473), (0.149, 0.949, -0.278)),
+    Frame((0.376, 0.087, 0.299), (0.850, 0.000, 0.528), (0.184, 0.937, -0.296)),
+]
 
-with AnalyticalPyBulletClient(connection_type='direct') as client:
+with AnalyticalPyBulletClient(connection_type="direct") as client:
     robot = client.load_ur5(load_geometry=True)
 
     options = {"solver": "ur5", "check_collision": True}
     start_configuration = list(robot.iter_inverse_kinematics(frames_WCF[0], options=options))[-1]
     trajectory = robot.plan_cartesian_motion(frames_WCF, start_configuration=start_configuration, options=options)
-    assert(trajectory.fraction == 1.)
+    assert trajectory.fraction == 1.0
 
     j = [c.joint_values for c in trajectory.points]
     plt.plot(j)

--- a/tests/backends/kinematics/test_inverse_kinematics.py
+++ b/tests/backends/kinematics/test_inverse_kinematics.py
@@ -4,13 +4,14 @@ from compas.robots.configuration import Configuration
 
 import compas_fab
 from compas_fab.backends import AnalyticalInverseKinematics
+from compas_fab.robots import Tool
 from compas_fab.robots.ur5 import Robot
 
 if not compas.IPY:
     from compas_fab.backends import AnalyticalPyBulletClient
 
-urdf_filename = compas_fab.get('universal_robot/ur_description/urdf/ur5.urdf')
-srdf_filename = compas_fab.get('universal_robot/ur5_moveit_config/config/ur5.srdf')
+urdf_filename = compas_fab.get("universal_robot/ur_description/urdf/ur5.urdf")
+srdf_filename = compas_fab.get("universal_robot/ur5_moveit_config/config/ur5.srdf")
 
 
 def test_inverse_kinematics():
@@ -19,10 +20,10 @@ def test_inverse_kinematics():
     frame_WCF = Frame((0.381, 0.093, 0.382), (0.371, -0.292, -0.882), (0.113, 0.956, -0.269))
     # set the solver later
     solutions = list(ik.inverse_kinematics(robot, frame_WCF, start_configuration=None, group=None, options={"solver": "ur5"}))
-    assert(len(solutions) == 8)
+    assert len(solutions) == 8
     joint_positions, _ = solutions[0]
     correct = Configuration.from_revolute_values((0.022, 4.827, 1.508, 1.126, 1.876, 3.163))
-    assert(correct.close_to(Configuration.from_revolute_values(joint_positions)))
+    assert correct.close_to(Configuration.from_revolute_values(joint_positions))
 
 
 def test_inverse_kinematics2():
@@ -31,37 +32,69 @@ def test_inverse_kinematics2():
     frame_WCF = Frame((0.381, 0.093, 0.382), (0.371, -0.292, -0.882), (0.113, 0.956, -0.269))
     # set the solver later
     solutions = list(ik.inverse_kinematics(robot, frame_WCF, start_configuration=None, group=None))
-    assert(len(solutions) == 8)
+    assert len(solutions) == 8
     joint_positions, _ = solutions[0]
     correct = Configuration.from_revolute_values((0.022, 4.827, 1.508, 1.126, 1.876, 3.163))
-    assert(correct.close_to(Configuration.from_revolute_values(joint_positions)))
+    assert correct.close_to(Configuration.from_revolute_values(joint_positions))
 
 
 def test_kinematics_client():
     if compas.IPY:
         return
     frame_WCF = Frame((0.381, 0.093, 0.382), (0.371, -0.292, -0.882), (0.113, 0.956, -0.269))
-    with AnalyticalPyBulletClient(connection_type='direct') as client:
+    with AnalyticalPyBulletClient(connection_type="direct") as client:
         robot = client.load_robot(urdf_filename)
         client.load_semantics(robot, srdf_filename)
         solutions = list(robot.iter_inverse_kinematics(frame_WCF, options={"solver": "ur5", "check_collision": True, "keep_order": False}))
-        assert(len(solutions) == 5)
+        assert len(solutions) == 5
+
+
+def test_kinematics_client_with_attached_tool_but_disabled_usage_of_tcf():
+    if compas.IPY:
+        return
+    frame_WCF = Frame((0.381, 0.093, 0.382), (0.371, -0.292, -0.882), (0.113, 0.956, -0.269))
+    with AnalyticalPyBulletClient(connection_type="direct") as client:
+        robot = client.load_robot(urdf_filename)
+        client.load_semantics(robot, srdf_filename)
+
+        tool_frame = Frame([0.0, 0, 0], [0, 1, 0], [0, 0, 1])
+        robot.attach_tool(Tool(visual=None, frame_in_tool0_frame=tool_frame))
+
+        solutions = list(robot.iter_inverse_kinematics(frame_WCF, use_attached_tool_frame=False, options={"solver": "ur5", "check_collision": True, "keep_order": False}))
+        assert len(solutions) == 5
+
+
+def test_kinematics_client_with_attached_tool():
+    if compas.IPY:
+        return
+    frame_WCF = Frame((0.381, 0.093, 0.382), (0.371, -0.292, -0.882), (0.113, 0.956, -0.269))
+    with AnalyticalPyBulletClient(connection_type="direct") as client:
+        robot = client.load_robot(urdf_filename)
+        client.load_semantics(robot, srdf_filename)
+
+        tool_frame = Frame([0, 0, 0.6], [1, 0, 0], [0, 1, 0])
+        robot.attach_tool(Tool(visual=None, frame_in_tool0_frame=tool_frame))
+
+        solutions = list(robot.iter_inverse_kinematics(frame_WCF, options={"solver": "ur5", "check_collision": True, "keep_order": False}))
+        assert len(solutions) == 4
 
 
 def test_kinematics_cartesian():
     if compas.IPY:
         return
-    frames_WCF = [Frame((0.407, 0.073, 0.320), (0.922, 0.000, 0.388), (0.113, 0.956, -0.269)),
-                  Frame((0.404, 0.057, 0.324), (0.919, 0.000, 0.394), (0.090, 0.974, -0.210)),
-                  Frame((0.390, 0.064, 0.315), (0.891, 0.000, 0.454), (0.116, 0.967, -0.228)),
-                  Frame((0.388, 0.079, 0.309), (0.881, 0.000, 0.473), (0.149, 0.949, -0.278)),
-                  Frame((0.376, 0.087, 0.299), (0.850, 0.000, 0.528), (0.184, 0.937, -0.296))]
+    frames_WCF = [
+        Frame((0.407, 0.073, 0.320), (0.922, 0.000, 0.388), (0.113, 0.956, -0.269)),
+        Frame((0.404, 0.057, 0.324), (0.919, 0.000, 0.394), (0.090, 0.974, -0.210)),
+        Frame((0.390, 0.064, 0.315), (0.891, 0.000, 0.454), (0.116, 0.967, -0.228)),
+        Frame((0.388, 0.079, 0.309), (0.881, 0.000, 0.473), (0.149, 0.949, -0.278)),
+        Frame((0.376, 0.087, 0.299), (0.850, 0.000, 0.528), (0.184, 0.937, -0.296)),
+    ]
 
-    with AnalyticalPyBulletClient(connection_type='direct') as client:
+    with AnalyticalPyBulletClient(connection_type="direct") as client:
         robot = client.load_robot(urdf_filename)
         client.load_semantics(robot, srdf_filename)
 
         options = {"solver": "ur5", "check_collision": True}
         start_configuration = list(robot.iter_inverse_kinematics(frames_WCF[0], options=options))[-1]
         trajectory = robot.plan_cartesian_motion(frames_WCF, start_configuration=start_configuration, options=options)
-        assert(trajectory.fraction == 1.)
+        assert trajectory.fraction == 1.0

--- a/tests/robots/test_robot.py
+++ b/tests/robots/test_robot.py
@@ -1,3 +1,4 @@
+import math
 import os
 import re
 
@@ -11,8 +12,8 @@ from compas_fab.backends.interfaces import ClientInterface
 from compas_fab.backends.interfaces import InverseKinematics
 from compas_fab.backends.interfaces import PlannerInterface
 from compas_fab.robots import Robot
-from compas_fab.robots import Tool
 from compas_fab.robots import RobotSemantics
+from compas_fab.robots import Tool
 from compas_fab.robots.ur5 import Robot as Ur5Robot
 
 BASE_FOLDER = os.path.dirname(__file__)
@@ -20,12 +21,12 @@ BASE_FOLDER = os.path.dirname(__file__)
 
 @pytest.fixture
 def panda_srdf():
-    return os.path.join(BASE_FOLDER, 'fixtures', 'panda_semantics.srdf')
+    return os.path.join(BASE_FOLDER, "fixtures", "panda_semantics.srdf")
 
 
 @pytest.fixture
 def panda_urdf():
-    return os.path.join(BASE_FOLDER, 'fixtures', 'panda.urdf')
+    return os.path.join(BASE_FOLDER, "fixtures", "panda.urdf")
 
 
 @pytest.fixture
@@ -62,8 +63,16 @@ def ur5_with_fake_ik(ur5_robot_instance, fake_client):
     class FakeInverseKinematics(InverseKinematics):
         def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
             results = [
-                ((-1.572, -2.560, 2.196, 2.365, 0.001, 1.137), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint')),
-                ((-2.238, -3.175, 2.174, 4.143, -5.616, -6.283), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint')),
+                (
+                    (-1.572, -2.560, 2.196, 2.365, 0.001, 1.137),
+                    (0, 0, 0, 0, 0, 0),
+                    ("shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", "wrist_1_joint", "wrist_2_joint", "wrist_3_joint"),
+                ),
+                (
+                    (-2.238, -3.175, 2.174, 4.143, -5.616, -6.283),
+                    (0, 0, 0, 0, 0, 0),
+                    ("shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", "wrist_1_joint", "wrist_2_joint", "wrist_3_joint"),
+                ),
             ]
 
             for ik in results:
@@ -101,158 +110,158 @@ def fake_client():
 
 @pytest.fixture
 def robot_tool1():
-    mesh = Mesh.from_stl(compas_fab.get('planning_scene/cone.stl'))
+    mesh = Mesh.from_stl(compas_fab.get("planning_scene/cone.stl"))
     frame = Frame([0.14, 0, 0], [0, 1, 0], [0, 0, 1])
     return Tool(mesh, frame)
 
 
 @pytest.fixture
 def robot_tool2():
-    mesh = Mesh.from_stl(compas_fab.get('planning_scene/cone.stl'))
+    mesh = Mesh.from_stl(compas_fab.get("planning_scene/cone.stl"))
     frame = Frame([0.89, 0, 0], [0, 1, 0], [0, 0, 1])
     return Tool(mesh, frame)
 
 
 def test_basic_name_only():
-    robot = Robot.basic('testbot')
+    robot = Robot.basic("testbot")
     assert robot.artist is None
 
 
 def test_basic_name_joints_links(ur5_joints, ur5_links):
-    robot = Robot.basic('testbot', joints=ur5_joints, links=ur5_links)
+    robot = Robot.basic("testbot", joints=ur5_joints, links=ur5_links)
     assert len(robot.model.links) == 11
     assert len(robot.get_configurable_joint_names()) == 6
 
 
 def test_basic_name_joints(ur5_joints):
-    robot = Robot.basic('testbot', joints=ur5_joints)
+    robot = Robot.basic("testbot", joints=ur5_joints)
     assert len(robot.model.joints) == 10
 
 
 def test_basic_name_links(ur5_links):
-    robot = Robot.basic('testbot', links=ur5_links)
+    robot = Robot.basic("testbot", links=ur5_links)
     assert len(robot.model.links) == 11
 
 
 def test_basic_attr():
-    robot = Robot.basic('testbot', location='rfl')
-    assert robot.model.attr['location'] == 'rfl'
+    robot = Robot.basic("testbot", location="rfl")
+    assert robot.model.attr["location"] == "rfl"
 
 
 def test_name(panda_robot_instance):
     robot = panda_robot_instance
-    assert robot.name == 'panda'
+    assert robot.name == "panda"
 
 
 def test_group_names(ur5_robot_instance):
     robot = ur5_robot_instance
-    assert sorted(robot.group_names) == ['endeffector', 'manipulator']
+    assert sorted(robot.group_names) == ["endeffector", "manipulator"]
 
 
 def test_main_group_name(panda_robot_instance):
     robot = panda_robot_instance
-    assert robot.main_group_name == 'panda_arm_hand'
+    assert robot.main_group_name == "panda_arm_hand"
 
 
 def test_root_name(ur5_robot_instance):
     robot = ur5_robot_instance
-    assert robot.root_name == 'world'
+    assert robot.root_name == "world"
 
 
 def test_get_end_effector_link_name(panda_robot_instance):
     robot = panda_robot_instance
-    assert robot.get_end_effector_link_name(group=None) == 'panda_rightfinger'
-    assert robot.get_end_effector_link_name(group='panda_arm_hand') == 'panda_rightfinger'
-    assert robot.get_end_effector_link_name(group='panda_arm') == 'panda_link8'
+    assert robot.get_end_effector_link_name(group=None) == "panda_rightfinger"
+    assert robot.get_end_effector_link_name(group="panda_arm_hand") == "panda_rightfinger"
+    assert robot.get_end_effector_link_name(group="panda_arm") == "panda_link8"
 
 
 def test_get_end_effector_link_name_wrong_group(panda_robot_instance):
     robot = panda_robot_instance
     with pytest.raises(KeyError):
-        robot.get_end_effector_link_name(group='panda_leg')
+        robot.get_end_effector_link_name(group="panda_leg")
 
 
 def test_get_end_effector_link(ur5_robot_instance):
     robot = ur5_robot_instance
 
     assert robot.get_end_effector_link(group=None).name == "ee_link"
-    assert robot.get_end_effector_link(group='endeffector').name == "ee_link"
+    assert robot.get_end_effector_link(group="endeffector").name == "ee_link"
 
 
 def test_get_end_effector_frame(panda_robot_instance):
     robot = panda_robot_instance
-    assert round(robot.get_end_effector_frame(group=None).point.x, 3) == .301
-    assert round(robot.get_end_effector_frame(group='panda_arm').point.x, 3) == .359
+    assert round(robot.get_end_effector_frame(group=None).point.x, 3) == 0.301
+    assert round(robot.get_end_effector_frame(group="panda_arm").point.x, 3) == 0.359
 
 
 def test_get_base_link_name(ur5_robot_instance):
     robot = ur5_robot_instance
 
-    assert robot.get_base_link_name(group=None) == 'base_link'
-    assert robot.get_base_link_name(group='endeffector') == 'ee_link'
+    assert robot.get_base_link_name(group=None) == "base_link"
+    assert robot.get_base_link_name(group="endeffector") == "ee_link"
 
 
 def test_get_base_link_name_wo_semantics(panda_robot_instance_wo_semantics):
     robot = panda_robot_instance_wo_semantics
 
-    assert robot.get_base_link_name(group=None) == 'panda_link0'
-    assert robot.get_base_link_name(group='endeffector') == 'panda_link0'
+    assert robot.get_base_link_name(group=None) == "panda_link0"
+    assert robot.get_base_link_name(group="endeffector") == "panda_link0"
 
 
 def test_get_base_link(panda_robot_instance):
     robot = panda_robot_instance
 
     link = robot.get_base_link(group=None)
-    assert link.name == 'panda_link0'
+    assert link.name == "panda_link0"
 
-    link = robot.get_base_link(group='panda_arm')
-    assert link.name == 'panda_link0'
+    link = robot.get_base_link(group="panda_arm")
+    assert link.name == "panda_link0"
 
-    link = robot.get_base_link(group='hand')
-    assert link.name == 'panda_hand'
+    link = robot.get_base_link(group="hand")
+    assert link.name == "panda_hand"
 
 
 def test_get_base_link_wo_semantics(panda_robot_instance_wo_semantics):
     robot = panda_robot_instance_wo_semantics
 
     link = robot.get_base_link(group=None)
-    assert link.name == 'panda_link0'
+    assert link.name == "panda_link0"
 
-    link = robot.get_base_link(group='panda_arm')
-    assert link.name == 'panda_link0'
+    link = robot.get_base_link(group="panda_arm")
+    assert link.name == "panda_link0"
 
-    link = robot.get_base_link(group='hand')
-    assert link.name == 'panda_link0'
+    link = robot.get_base_link(group="hand")
+    assert link.name == "panda_link0"
 
 
 def test_get_base_frame(panda_robot_instance):
     robot = panda_robot_instance
 
     assert robot.get_base_frame(group=None) == Frame.worldXY()
-    assert robot.get_base_frame(group='panda_arm') == Frame.worldXY()
+    assert robot.get_base_frame(group="panda_arm") == Frame.worldXY()
 
 
 def test_get_base_frame_w_artist(panda_robot_instance_w_artist):
     robot = panda_robot_instance_w_artist
 
     assert robot.get_base_frame(group=None) == Frame.worldXY()
-    assert robot.get_base_frame(group='panda_arm') == Frame.worldXY()
+    assert robot.get_base_frame(group="panda_arm") == Frame.worldXY()
 
 
 def test_get_base_frame_when_link_has_parent(ur5_robot_instance):
     robot = ur5_robot_instance
-    base_frame = robot.get_base_frame(group='endeffector')
+    base_frame = robot.get_base_frame(group="endeffector")
 
     assert [round(v, 3) for v in list(base_frame.point)] == [0.817, 0.191, -0.005]
-    assert [round(v) for v in base_frame.data['xaxis']] == [0, 1, 0]
-    assert [round(v) for v in base_frame.data['yaxis']] == [1, 0, 0]
+    assert [round(v) for v in base_frame.data["xaxis"]] == [0, 1, 0]
+    assert [round(v) for v in base_frame.data["yaxis"]] == [1, 0, 0]
 
 
 def test_get_configurable_joints(ur5_robot_instance):
     robot = ur5_robot_instance
     joints = robot.get_configurable_joints()
 
-    pattern = re.compile(r'(shoulder|wrist|elbow).*_joint')
+    pattern = re.compile(r"(shoulder|wrist|elbow).*_joint")
     matches = [pattern.match(joint.name) for joint in joints]
     assert all(matches)
 
@@ -261,7 +270,7 @@ def test_get_configurable_joints_wo_semantics(panda_robot_instance_wo_semantics)
     robot = panda_robot_instance_wo_semantics
     joints = robot.get_configurable_joints()
 
-    pattern = re.compile(r'panda_.*joint\d')
+    pattern = re.compile(r"panda_.*joint\d")
     matches = [pattern.match(joint.name) for joint in joints]
     assert all(matches)
 
@@ -273,11 +282,20 @@ def test_inverse_kinematics_repeated_calls_will_return_next_result(ur5_with_fake
     start_config = robot.zero_configuration()
 
     configuration = robot.inverse_kinematics(frame, start_config)
-    assert str(configuration) == "Configuration((-1.572, -2.560, 2.196, 2.365, 0.001, 1.137), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
+    assert (
+        str(configuration)
+        == "Configuration((-1.572, -2.560, 2.196, 2.365, 0.001, 1.137), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
+    )
     configuration = robot.inverse_kinematics(frame, start_config)
-    assert str(configuration) == "Configuration((-2.238, -3.175, 2.174, 4.143, -5.616, -6.283), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
+    assert (
+        str(configuration)
+        == "Configuration((-2.238, -3.175, 2.174, 4.143, -5.616, -6.283), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
+    )
     configuration = robot.inverse_kinematics(frame, start_config)
-    assert str(configuration) == "Configuration((-1.572, -2.560, 2.196, 2.365, 0.001, 1.137), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
+    assert (
+        str(configuration)
+        == "Configuration((-1.572, -2.560, 2.196, 2.365, 0.001, 1.137), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
+    )
 
 
 def test_iter_inverse_kinematics(ur5_with_fake_ik):
@@ -288,8 +306,31 @@ def test_iter_inverse_kinematics(ur5_with_fake_ik):
 
     solutions = list(robot.iter_inverse_kinematics(frame, start_config))
     assert len(solutions) == 2
-    assert str(solutions[0]) == "Configuration((-1.572, -2.560, 2.196, 2.365, 0.001, 1.137), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
-    assert str(solutions[1]) == "Configuration((-2.238, -3.175, 2.174, 4.143, -5.616, -6.283), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
+    assert (
+        str(solutions[0])
+        == "Configuration((-1.572, -2.560, 2.196, 2.365, 0.001, 1.137), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
+    )
+    assert (
+        str(solutions[1])
+        == "Configuration((-2.238, -3.175, 2.174, 4.143, -5.616, -6.283), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))"
+    )
+
+
+def test_forward_kinematics_without_tool(ur5_robot_instance):
+    robot = ur5_robot_instance
+
+    frame_t0cf = robot.forward_kinematics(robot.zero_configuration())
+    assert str(frame_t0cf) == "Frame(Point(0.817, 0.191, -0.005), Vector(-0.000, 1.000, 0.000), Vector(1.000, 0.000, 0.000))"
+
+
+def test_forward_kinematics_with_tool(ur5_robot_instance, robot_tool1):
+    robot = ur5_robot_instance
+    tool = robot_tool1
+
+    robot.attach_tool(tool)
+    frame_t0cf = robot.forward_kinematics(robot.zero_configuration(), use_attached_tool_frame=False)
+    frame_tcf = robot.forward_kinematics(robot.zero_configuration(), use_attached_tool_frame=True)
+    assert math.fabs(frame_t0cf.point.y - frame_tcf.point.y) == tool.frame.point.x
 
 
 def test_attach_tool_without_group(ur5_robot_instance, robot_tool1):
@@ -361,7 +402,7 @@ def test_detach_tool_with_group(ur5_robot_instance, robot_tool1):
     assert len(robot.attached_tools) == 0
 
 
-def test_wrond_gorup_name_raises_exception(ur5_robot_instance, robot_tool1):
+def test_wrong_group_name_raises_exception(ur5_robot_instance, robot_tool1):
     robot = ur5_robot_instance
     tool = robot_tool1
     wrong_group_name = "theavengers"


### PR DESCRIPTION
No more manual tcf-to-t0cf (and viceversa) conversions. Now if there's a tool attached in the planning group, it will use its frame for the planning request (IK, FK, cartesian and kinematic planning).

Although the change does not break the API itself, the default behavior is a breaking change, but one I would propose we just accept and mark it with semver.

Re. https://forum.compas-framework.org/t/planning-with-tcf-after-attaching-a-tool-ros-backend/581


### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
