### PR TITLE
Add scene cache to 'Visualize Robot" component

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
-          python -m pip install cython --install-option="--no-cython-compile"
+          python -m pip install cython --config-settings="--build-option=--no-cython-compile"
       - name: Install
         run: |
           python -m pip install --no-cache-dir -r requirements-dev.txt

--- a/.github/workflows/deploy-n-publish.yml
+++ b/.github/workflows/deploy-n-publish.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
-          python -m pip install cython --install-option="--no-cython-compile"
+          python -m pip install cython --config-settings="--build-option=--no-cython-compile"
       - name: 💎 Install
         run: |
           python -m pip install --no-cache-dir -r requirements-dev.txt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install wheel
-          python -m pip install cython --install-option="--no-cython-compile"
+          python -m pip install cython --config-settings="--build-option=--no-cython-compile"
       - name: Install
         run: |
           python -m pip install --no-cache-dir -r requirements-dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Changed**
 
 * Updated install process of GH components.
+* Added caching to the GH component that visualizes scene, to avoid retrieving the whole scene too often.
 
 **Fixed**
 

--- a/src/compas_fab/ghpython/components/Cf_VisualizeRobot/code.py
+++ b/src/compas_fab/ghpython/components/Cf_VisualizeRobot/code.py
@@ -29,7 +29,6 @@ class RobotVisualize(component):
         show_cm,
         show_acm,
     ):
-
         visual = None
         collision = None
         collision_meshes = None


### PR DESCRIPTION
This is a small but noticeable performance optimization when there are lots of collision meshes in the scene. It prevents the retrieval and reloading of the scene constantly, and instead caches it for a couple of seconds. 
This very short cache is enough to prevent reloading while the user is, eg. dragging a slider to update the robot:
![perf-viz-robot](https://user-images.githubusercontent.com/933277/233866113-992f8b29-6c8c-425d-a515-e51cd02efb22.gif)

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
