### PR TITLE
Changed classes to inherete from compas.Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* `CollisionMesh` now inherit from `compas.data.Data`
+* `AttachedCollisionMesh` now inherit from `compas.data.Data`
+* `Robot` now inherit from `compas.data.Data`
+* `RobotSemantics` now inherit from `compas.data.Data`
+* `Tool` now inherit from `compas.data.Data`
+
 ### Removed
 
 

--- a/src/compas_fab/robots/planning_scene.py
+++ b/src/compas_fab/robots/planning_scene.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from compas.data import Data
 from compas.datastructures import Mesh
 from compas.geometry import Frame
 from compas.geometry import Scale
@@ -13,7 +14,7 @@ __all__ = [
 ]
 
 
-class CollisionMesh(object):
+class CollisionMesh(Data):
     """Represents a collision mesh.
 
     Parameters
@@ -55,6 +56,7 @@ class CollisionMesh(object):
     """
 
     def __init__(self, mesh, id, frame=None, root_name=None):
+        super(CollisionMesh, self).__init__()
         self.id = id
         self.mesh = mesh
         self.frame = frame or Frame.worldXY()
@@ -130,7 +132,7 @@ class CollisionMesh(object):
         self.root_name = data_obj["root_name"]
 
 
-class AttachedCollisionMesh(object):
+class AttachedCollisionMesh(Data):
     """Represents a collision mesh that is attached to a :class:`Robot`'s :class:`~compas.robots.Link`.
 
     Parameters
@@ -169,6 +171,7 @@ class AttachedCollisionMesh(object):
     """
 
     def __init__(self, collision_mesh, link_name, touch_links=None, weight=1.0):
+        super(AttachedCollisionMesh, self).__init__()
         self.collision_mesh = collision_mesh
         if self.collision_mesh:
             self.collision_mesh.root_name = link_name
@@ -224,7 +227,7 @@ class AttachedCollisionMesh(object):
         self.weight = data_obj["weight"]
 
 
-class PlanningScene(object):
+class PlanningScene(Data):
     """Represents the planning scene.
 
     Parameters
@@ -241,6 +244,7 @@ class PlanningScene(object):
     """
 
     def __init__(self, robot):
+        super(PlanningScene, self).__init__()
         self.robot = robot
 
     @property

--- a/src/compas_fab/robots/planning_scene.py
+++ b/src/compas_fab/robots/planning_scene.py
@@ -227,7 +227,7 @@ class AttachedCollisionMesh(Data):
         self.weight = data_obj["weight"]
 
 
-class PlanningScene(Data):
+class PlanningScene(object):
     """Represents the planning scene.
 
     Parameters
@@ -244,7 +244,6 @@ class PlanningScene(Data):
     """
 
     def __init__(self, robot):
-        super(PlanningScene, self).__init__()
         self.robot = robot
 
     @property

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -65,9 +65,10 @@ class Robot(Data):
     @property
     def data(self):
         data = {
-            "_scale_factor": self._scale_factor,
-            "_attached_tools": self._attached_tools,
-            "_current_ik": self._current_ik,
+            "scale_factor": self._scale_factor,
+            "attached_tools": self._attached_tools,
+            # The current_ik is an extrinsic state that is not serialized with the robot
+            # "current_ik": self._current_ik,
             "model": self.model.data,
             "semantics": self.semantics,
             "attributes": self.attributes,
@@ -79,9 +80,8 @@ class Robot(Data):
 
     @data.setter
     def data(self, data):
-        self._scale_factor = data.get("_scale_factor", 1.0)
-        self._attached_tools = data.get("_attached_tools", {})
-        self._current_ik = data.get("_current_ik", {"request_id": None, "solutions": None})
+        self._scale_factor = data.get("scale_factor", 1.0)
+        self._attached_tools = data.get("attached_tools", {})
         self.model = RobotModel.from_data(data["model"])
         self.semantics = data.get("semantics", None)
         self.attributes = data.get("attributes", {})

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -69,10 +69,10 @@ class Robot(Data):
             "_attached_tools": self._attached_tools,
             "_current_ik": self._current_ik,
             "model": self.model.data,
+            "semantics": self.semantics,
             "attributes": self.attributes,
             # The following attributes cannnot be serizlied
             # "artist": self.artist.data if self.artist else None,
-            # "semantics": self.semantics.data if self.semantics else None,
             # "client": self.client.data if self.client else None,
         }
         return data
@@ -83,6 +83,7 @@ class Robot(Data):
         self._attached_tools = data.get("_attached_tools", {})
         self._current_ik = data.get("_current_ik", {"request_id": None, "solutions": None})
         self.model = RobotModel.from_data(data["model"])
+        self.semantics = data.get("semantics", None)
         self.attributes = data.get("attributes", {})
 
     @property

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -50,7 +50,7 @@ class Robot(Data):
 
     def __init__(self, model=None, artist=None, semantics=None, client=None):
         super(Robot, self).__init__()
-        # These attributes have to be initiated first, 
+        # These attributes have to be initiated first,
         # because they are used in the setters of the other attributes
         self._scale_factor = 1.0
         self._attached_tools = {}  # { planning_group_name: robots.tool.Tool }
@@ -65,27 +65,25 @@ class Robot(Data):
     @property
     def data(self):
         data = {
-            '_scale_factor': self._scale_factor,
-            '_attached_tools': self._attached_tools,
-            '_current_ik': self._current_ik,
-            'model': self.model.data,
-            # 'artist': self.artist.data if self.artist else None,
-            # 'semantics': self.semantics.data if self.semantics else None,
-            # 'client': self.client.data if self.client else None,
-            'attributes': self.attributes,
+            "_scale_factor": self._scale_factor,
+            "_attached_tools": self._attached_tools,
+            "_current_ik": self._current_ik,
+            "model": self.model.data,
+            "attributes": self.attributes,
+            # The following attributes cannnot be serizlied
+            # "artist": self.artist.data if self.artist else None,
+            # "semantics": self.semantics.data if self.semantics else None,
+            # "client": self.client.data if self.client else None,
         }
         return data
 
     @data.setter
     def data(self, data):
-        self._scale_factor = data.get('_scale_factor', 1.0)
-        self._attached_tools = data.get('_attached_tools', {})
-        self._current_ik = data.get('_current_ik', {"request_id": None, "solutions": None})
-        self.model = RobotModel.from_data(data['model'])
-        # self.artist = data.get('artist', None)
-        # self.semantics = data.get('semantics', None)
-        # self.client = data.get('client', None)
-        self.attributes = data.get('attributes', {})
+        self._scale_factor = data.get("_scale_factor", 1.0)
+        self._attached_tools = data.get("_attached_tools", {})
+        self._current_ik = data.get("_current_ik", {"request_id": None, "solutions": None})
+        self.model = RobotModel.from_data(data["model"])
+        self.attributes = data.get("attributes", {})
 
     @property
     def artist(self):

--- a/src/compas_fab/robots/semantics.py
+++ b/src/compas_fab/robots/semantics.py
@@ -3,13 +3,14 @@ from __future__ import division
 from __future__ import print_function
 
 from compas.files import XML
+from compas.data import Data
 
 __all__ = [
     "RobotSemantics",
 ]
 
 
-class RobotSemantics(object):
+class RobotSemantics(Data):
     """Represents semantic information of a robot.
 
     The semantic model is based on the

--- a/src/compas_fab/robots/semantics.py
+++ b/src/compas_fab/robots/semantics.py
@@ -33,6 +33,7 @@ class RobotSemantics(Data):
         disabled_collisions=None,
         group_states=None,
     ):
+        super(RobotSemantics, self).__init__()
         self.robot_model = robot_model
 
         self.groups = groups or {}
@@ -50,7 +51,7 @@ class RobotSemantics(Data):
             "main_group_name": self.main_group_name,
             "passive_joints": self.passive_joints,
             "end_effectors": self.end_effectors,
-            "disabled_collisions": self.disabled_collisions,
+            "disabled_collisions": sorted(self.disabled_collisions),
             "group_states": self.group_states,
         }
         return data
@@ -63,6 +64,8 @@ class RobotSemantics(Data):
         self.passive_joints = data.get("passive_joints", [])
         self.end_effectors = data.get("end_effectors", [])
         self.disabled_collisions = data.get("disabled_collisions", set())
+        if len(self.disabled_collisions) > 0:
+            self.disabled_collisions = {tuple(pair) for pair in self.disabled_collisions}
         self.group_states = data.get("group_states", {})
 
     @classmethod

--- a/src/compas_fab/robots/semantics.py
+++ b/src/compas_fab/robots/semantics.py
@@ -43,6 +43,35 @@ class RobotSemantics(Data):
         self.group_states = group_states or {}
 
     @property
+    def data(self):
+        data = {
+            "robot_model": self.robot_model,
+            "groups": self.groups,
+            "main_group_name": self.main_group_name,
+            "passive_joints": self.passive_joints,
+            "end_effectors": self.end_effectors,
+            "disabled_collisions": self.disabled_collisions,
+            "group_states": self.group_states,
+        }
+        return data
+
+    @data.setter
+    def data(self, data):
+        self.robot_model = data.get("robot_model", None)
+        self.groups = data.get("groups", {})
+        self.main_group_name = data.get("main_group_name", None)
+        self.passive_joints = data.get("passive_joints", [])
+        self.end_effectors = data.get("end_effectors", [])
+        self.disabled_collisions = data.get("disabled_collisions", set())
+        self.group_states = data.get("group_states", {})
+
+    @classmethod
+    def from_data(cls, data):
+        robot_semantics = cls(None)
+        robot_semantics.data = data
+        return robot_semantics
+
+    @property
     def group_names(self):
         return list(self.groups.keys())
 

--- a/src/compas_fab/robots/tool.py
+++ b/src/compas_fab/robots/tool.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import json
 
+from compas.data import Data
 from compas.robots import Geometry
 from compas.robots import ToolModel
 
@@ -14,7 +15,7 @@ from compas_fab.robots.planning_scene import CollisionMesh
 __all__ = ["Tool"]
 
 
-class Tool(object):
+class Tool(Data):
     """Represents a tool to be attached to the robot's flange.
 
     Attributes
@@ -39,7 +40,9 @@ class Tool(object):
     """
 
     def __init__(self, visual, frame_in_tool0_frame, collision=None, name="attached_tool", link_name=None):
+        super(Tool, self).__init__()
         self.tool_model = ToolModel(visual, frame_in_tool0_frame, collision, name, link_name)
+
 
     @classmethod
     def from_tool_model(cls, tool_model):

--- a/src/compas_fab/robots/tool.py
+++ b/src/compas_fab/robots/tool.py
@@ -43,7 +43,6 @@ class Tool(Data):
         super(Tool, self).__init__()
         self.tool_model = ToolModel(visual, frame_in_tool0_frame, collision, name, link_name)
 
-
     @classmethod
     def from_tool_model(cls, tool_model):
         tool = cls(None, None)

--- a/tests/robots/test_robot.py
+++ b/tests/robots/test_robot.py
@@ -3,7 +3,8 @@ import os
 import re
 
 import pytest
-from compas.data import json_dumps, json_loads
+from compas.data import json_dumps
+from compas.data import json_loads
 from compas.datastructures import Mesh
 from compas.geometry import Frame
 from compas.robots import RobotModel
@@ -321,10 +322,11 @@ def test_robot_serialization(panda_robot_instance):
 
 def test_robot_serialization_with_tool(ur5_robot_instance, robot_tool1):
     robot = ur5_robot_instance
-    tool = robot_tool1
-    robot.attach_tool(tool)
+    robot.attach_tool(robot_tool1)
+    # serialization and deserialization using compas data serialization
     robot_string = json_dumps(robot)
     robot2 = json_loads(robot_string)
+
     for tool in robot2.attached_tools.values():
         assert isinstance(tool, Tool)
     assert len(robot2.attached_tools) == 1

--- a/tests/robots/test_robot.py
+++ b/tests/robots/test_robot.py
@@ -296,6 +296,9 @@ def test_semantics_serialization(panda_srdf, panda_urdf):
     semantics = RobotSemantics.from_srdf_file(panda_srdf, model)
     semantics_string = json_dumps(semantics)
     semantics2 = json_loads(semantics_string)
+    assert semantics.main_group_name == semantics2.main_group_name
+    for group_name in semantics.group_names:
+        assert group_name in semantics2.group_names
     assert isinstance(semantics, RobotSemantics)
     assert isinstance(semantics2, RobotSemantics)
     for disabled_collision in semantics.disabled_collisions:


### PR DESCRIPTION
Some of the classes in compas_fab is still based on (object) instead of (Data)

I have selected some of the classes that should support serialization and upgrade them. Upgrading them should be backward compatible. However, it may affect user classes inherited from these classes. This RP does not cover all the classes yet (e.g. classes in backends, reachability map, ghpython and some more). Let me know if you think I should extend to cover all classes. 

@gonzalocasas Should I add test files for this? 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
