### PR TITLE
fix CI dependency on compas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          curl -o compas.tar.gz -LJO https://pypi.debian.net/compas/latest
+          curl -o compas.tar.gz -LJO https://pypi.debian.net/COMPAS/COMPAS-1.17.7.tar.gz
           curl -o roslibpy.tar.gz -LJO https://pypi.debian.net/roslibpy/latest
           curl -o ironpython-pytest.tar.gz -LJO https://pypi.debian.net/ironpython-pytest/latest
           choco install ironpython --version=2.7.8.1


### PR DESCRIPTION
The CI workflow for IronPython depends on Debian's mirror of PyPi to install wheels, such as compas, because pip generally fails miserably, but now that compas 2.0alpha is released, the debian mirror incorrectly takes that version as `/latest` and there's no `/stable` redirect, so, we need to pin to the latest LTS version.

Once `compas_fab` moves to 2.x, we could unpin this again.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
