### PR TITLE
Raise specific exceptions if backend feature is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Raise `BackendFeatureNotSupportedError` exceptions when a features is not supported by the planner, instead of generic `Exception`.
+
 ### Removed
 
 

--- a/src/compas_fab/backends/__init__.py
+++ b/src/compas_fab/backends/__init__.py
@@ -91,9 +91,10 @@ Exceptions
     :nosignatures:
 
     BackendError
+    BackendFeatureNotSupportedError
     CartesianMotionError
-    KinematicsError
     InverseKinematicsError
+    KinematicsError
 
 Interfaces
 ==========
@@ -108,8 +109,9 @@ import compas
 # Base imports
 from .exceptions import (
     BackendError,
-    KinematicsError,
+    BackendFeatureNotSupportedError,
     InverseKinematicsError,
+    KinematicsError,
 )
 from .tasks import (
     FutureResult,
@@ -158,8 +160,9 @@ if not compas.IPY:
 __all__ = [
     # Base
     "BackendError",
-    "KinematicsError",
+    "BackendFeatureNotSupportedError",
     "InverseKinematicsError",
+    "KinematicsError",
     "FutureResult",
     "CancellableFutureResult",
     # ROS

--- a/src/compas_fab/backends/exceptions.py
+++ b/src/compas_fab/backends/exceptions.py
@@ -4,8 +4,9 @@ from __future__ import print_function
 
 __all__ = [
     "BackendError",
-    "KinematicsError",
+    "BackendFeatureNotSupportedError",
     "InverseKinematicsError",
+    "KinematicsError",
 ]
 
 
@@ -15,6 +16,12 @@ class BackendError(Exception):
 
     def __init__(self, message):
         super(BackendError, self).__init__(message)
+
+
+class BackendFeatureNotSupportedError(Exception):
+    """Indicates that the selected backend does not support the selected feature."""
+
+    pass
 
 
 class KinematicsError(BackendError):

--- a/src/compas_fab/backends/interfaces/client.py
+++ b/src/compas_fab/backends/interfaces/client.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from compas_fab.backends.exceptions import BackendFeatureNotSupportedError
 
 
 def forward_docstring(backend_feature):
@@ -117,40 +118,40 @@ class PlannerInterface(object):
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     def forward_kinematics(self, *args, **kwargs):
         """Default method for planner.
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     def plan_motion(self, *args, **kwargs):
         """Default method for planner.
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     def plan_cartesian_motion(self, *args, **kwargs):
         """Default method for planner.
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     # ==========================================================================
     # collision objects and planning scene
@@ -161,67 +162,67 @@ class PlannerInterface(object):
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     def reset_planning_scene(self, *args, **kwargs):
         """Default method for planner.
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     def add_collision_mesh(self, *args, **kwargs):
         """Default method for planner.
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     def remove_collision_mesh(self, *args, **kwargs):
         """Default method for planner.
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     def append_collision_mesh(self, *args, **kwargs):
         """Default method for planner.
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     def add_attached_collision_mesh(self, *args, **kwargs):
         """Default method for planner.
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")
 
     def remove_attached_collision_mesh(self, *args, **kwargs):
         """Default method for planner.
 
         Raises
         ------
-        Exception
+        BackendFeatureNotSupportedError
             Planner does not have this feature.
         """
-        raise Exception("Assigned planner does not have this feature.")
+        raise BackendFeatureNotSupportedError("Assigned planner does not have this feature.")

--- a/src/compas_fab/ghpython/components/Cf_VisualizeRobot/code.py
+++ b/src/compas_fab/ghpython/components/Cf_VisualizeRobot/code.py
@@ -14,6 +14,7 @@ from compas_rhino.conversions import frame_to_rhino_plane
 from ghpythonlib.componentbase import executingcomponent as component
 from scriptcontext import sticky as st
 
+from compas_fab.backends import BackendFeatureNotSupportedError
 from compas_fab.robots import PlanningScene
 
 
@@ -89,7 +90,13 @@ class RobotVisualize(component):
 
                 if update_scene:
                     scene = PlanningScene(robot)
-                    scene = robot.client.get_planning_scene()
+                    try:
+                        scene = robot.client.get_planning_scene()
+                    except BackendFeatureNotSupportedError:
+                        print("The selected backend does not support displaying collision meshes. Feature disabled.")
+                        scene = None
+                        show_cm = False
+                        show_acm = False
 
                 if update_scene and show_cm:
                     collision_meshes = []

--- a/src/compas_fab/ghpython/components/Cf_VisualizeRobot/code.py
+++ b/src/compas_fab/ghpython/components/Cf_VisualizeRobot/code.py
@@ -93,7 +93,9 @@ class RobotVisualize(component):
                     try:
                         scene = robot.client.get_planning_scene()
                     except BackendFeatureNotSupportedError:
-                        print("The selected backend does not support displaying collision meshes. Feature disabled.")
+                        print(
+                            "The selected backend does not support collision meshes. If you need collision mesh support, use a different backend."
+                        )
                         scene = None
                         show_cm = False
                         show_acm = False


### PR DESCRIPTION
Without a specific exception, the "visualize robot" component cannot know why the planning scene part is failing when using the analytical IK solvers. So, this adds a new exception type and the component now checks for it and does not fail in that case, it simply disables showing things that will not work.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [x] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
