### PR TITLE
Fix Addition error in Duration() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Changed the behavior of Duration class when accepting both seconds (float) and nanoseconds (int) where the decimal point of seconds and the nanoseconds add up to more than 1 second.
+
 ### Removed
 
 

--- a/src/compas_fab/robots/time_.py
+++ b/src/compas_fab/robots/time_.py
@@ -20,6 +20,23 @@ class Duration(Data):
         Float representing number of seconds.
     nsecs: int
         Integer representing number of nanoseconds.
+
+    Examples
+    --------
+    >>> d = Duration(2, 5e8)
+    >>> d.seconds
+    2.5
+    >>> d = Duration(2.6, 0)
+    >>> d.seconds
+    2.6
+    >>> d = Duration(2.6, 5e8)
+    >>> d.secs
+    3
+    >>> d.nsecs
+    100000000
+    >>> d.seconds
+    3.1
+
     """
 
     def __init__(self, secs, nsecs):
@@ -29,6 +46,11 @@ class Duration(Data):
 
         self.secs = int(quotient)
         self.nsecs = int(remainder * sec_to_nano_factor) + int(nsecs)
+
+        # If nsecs is greater than 1 second, add the remainder back to secs
+        if self.nsecs >= sec_to_nano_factor:
+            self.secs += 1
+            self.nsecs -= int(sec_to_nano_factor)
 
     def __str__(self):
         return "Duration({!r}, {!r})".format(self.secs, self.nsecs)

--- a/tests/robots/test_duration.py
+++ b/tests/robots/test_duration.py
@@ -13,6 +13,8 @@ def test_ctor_takes_sec_as_float():
 
 def test_sec_remainder_add_to_nsec():
     d = Duration(2.6, 5e8)
+    assert d.secs == 3
+    assert d.nsecs == 1e8
     assert d.seconds == 3.1
 
 


### PR DESCRIPTION
Changed the behavior of Duration class when accepting both seconds (float) and nanoseconds (int) where the decimal point of seconds and the nanoseconds add up to more than 1 second.

In the following test (existing), the total duration is expected to be 3.1 seconds. 
```
def test_sec_remainder_add_to_nsec():
    d = Duration(2.6, 5e8)
    assert d.seconds == 3.1
```
However, existing implementation did not carry on the values from nsec to sec when the total value adds up.  The following test explains the more desirable behavior:

```
def test_sec_remainder_add_to_nsec():
    d = Duration(2.6, 5e8)
    assert d.secs == 3
    assert d.nsecs == 1e8
    assert d.seconds == 3.1
```
### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
