### PR TITLE
Plan_cartesian_motion uses Waypoints class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `Robot.plan_carteisan_motion()` now accepts `Waypoints` as target. Implementation for `FrameWaypoints` is supported with same functionality as before. Simply wrap `Frame` objects using `FrameWaypoints(frames)`.
+* `Robot.plan_cartesian_motion()` now accepts `Waypoints` as target. Implementation for `FrameWaypoints` is supported with same functionality as before. Simply wrap `Frame` objects using `FrameWaypoints(frames)`.
 * Changed `BoundingVolume`, `Constraint`, `JointConstraint`, `OrientationConstraint`, `PositionConstraint` to inherit from `compas.data.Data` class.
 * Change the signature of `plan_motion()` to use `target` (`Target` class) instead of `goal_constraints`. Only one target is accepted. Users who wish to compose their own constraint sets can still use `ConstraintSetTarget`.
 * Moved `Robot.orientation_constraint_from_frame()` to `OrientationConstraint.from_frame()`, as constraints are no longer intended for users to use directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* `Robot.plan_carteisan_motion()` now accepts `Waypoints` as target. Implementation for `FrameWaypoints` is supported with same functionality as before. Simply wrap `Frame` objects using `FrameWaypoints(frames)`.
 * Changed `BoundingVolume`, `Constraint`, `JointConstraint`, `OrientationConstraint`, `PositionConstraint` to inherit from `compas.data.Data` class.
 * Change the signature of `plan_motion()` to use `target` (`Target` class) instead of `goal_constraints`. Only one target is accepted. Users who wish to compose their own constraint sets can still use `ConstraintSetTarget`.
 * Moved `Robot.orientation_constraint_from_frame()` to `OrientationConstraint.from_frame()`, as constraints are no longer intended for users to use directly.

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -38,3 +38,10 @@ The :class:`compas_fab.robots.ConstraintSetTarget` class is used to specify a li
 constraints as a planning target. This is intended for advanced users who want to create custom
 combination of constraints. See :class:`compas_fab.robots.Constraint` for available
 constraints. At the moment, only the ROS MoveIt planning backend supports this target type.
+
+------------------------------------------
+Waypoints Target (Multiple Point Segments)
+------------------------------------------
+
+The :class:`compas_fab.robots.Waypoint` classes are used to describe a sequence of
+waypoints that the robot should pass through.

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -38,6 +38,8 @@ constraints as a planning target. This is intended for advanced users who want t
 combination of constraints. See :class:`compas_fab.robots.Constraint` for available
 constraints. At the moment, only the ROS MoveIt planning backend supports this target type.
 
+.. _waypoints:
+
 ------------------------------------------
 Waypoints (Multiple Points / Segments)
 ------------------------------------------

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -1,16 +1,15 @@
 .. _targets:
 
 *******************************************************************************
-Targets
+Targets and Waypoints
 *******************************************************************************
 
 -----------------------
-Single Targets (Static)
+Targets (Single Goal)
 -----------------------
 
 Target classes are used to describe the goal condition (i.e. end condition) of a robot
-for motion planning. They can be used for both Free Motion Planning (FMP) and Cartesian
-Motion Planning (CMP).
+for motion planning. They can be used for Free Motion Planning with :meth:`compas_fab.robots.Robot.plan_motion`.
 
 The :class:`compas_fab.robots.FrameTarget` is the most common target for motion planning.
 It defines the complete pose of the end-effector (or the robot flange, if no tool is attached).
@@ -40,8 +39,25 @@ combination of constraints. See :class:`compas_fab.robots.Constraint` for availa
 constraints. At the moment, only the ROS MoveIt planning backend supports this target type.
 
 ------------------------------------------
-Waypoints Target (Multiple Point Segments)
+Waypoints (Multiple Points / Segments)
 ------------------------------------------
 
-The :class:`compas_fab.robots.Waypoint` classes are used to describe a sequence of
-waypoints that the robot should pass through.
+The :class:`compas_fab.robots.Waypoints` classes are used to describe a sequence of
+waypoints that the robot should pass through in a planned motion. They are similar to Targets classes
+but contain a list of targets instead of a single target, which is useful for tasks such as
+drawing, welding or 3D printing.
+They can be used for Cartesian Motion Planning with :meth:`compas_fab.robots.Robot.plan_cartesian_motion`.
+
+The :class:`compas_fab.robots.FrameWaypoints` is the most common waypoint for Cartesian motion planning.
+It defines a list of complete pose for the end-effector (or the robot flange, if no tool is attached).
+It is created by a list of :class:`compas.geometry.Frame` objects or alternatively from a list of
+:class:`compas.geometry.Transformation` objects.
+
+The :class:`compas_fab.robots.PointAxisWaypoints` class is used for specifying a list of waypoints based on
+the Point-Axis concept used in the :class:`compas_fab.robots.PointAxisTarget`. Compared to
+:class:`~compas_fab.robots.FrameWaypoints`, this class allows for specifying a targets where the rotation
+around the Z-axis is not fixed. This is useful for example when the robot is using a cylindrical tool
+to perform a task, for example 3D printing, welding or drilling. The freely rotating axis is defined relative
+to the Z-axis of the tool coordinate frame (TCF). Note that the orientation of the tool
+at the end of the motion is not determined until after the motion is planned.
+

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -9,7 +9,7 @@ Targets (Single Goal)
 -----------------------
 
 Target classes are used to describe the goal condition (i.e. end condition) of a robot
-for motion planning. They can be used for Free Motion Planning with :meth:`compas_fab.robots.Robot.plan_motion`.
+for motion planning. They can be used for Free-space Motion Planning with :meth:`compas_fab.robots.Robot.plan_motion`.
 
 The :class:`compas_fab.robots.FrameTarget` is the most common target for motion planning.
 It defines the complete pose of the end-effector (or the robot flange, if no tool is attached).
@@ -42,7 +42,7 @@ constraints. At the moment, only the ROS MoveIt planning backend supports this t
 Waypoints (Multiple Points / Segments)
 ------------------------------------------
 
-The :class:`compas_fab.robots.Waypoints` classes are used to describe a sequence of
+Waypoints classes are used to describe a sequence of
 waypoints that the robot should pass through in a planned motion. They are similar to Targets classes
 but contain a list of targets instead of a single target, which is useful for tasks such as
 drawing, welding or 3D printing.

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -55,7 +55,7 @@ It is created by a list of :class:`compas.geometry.Frame` objects or alternative
 
 The :class:`compas_fab.robots.PointAxisWaypoints` class is used for specifying a list of waypoints based on
 the Point-Axis concept used in the :class:`compas_fab.robots.PointAxisTarget`. Compared to
-:class:`~compas_fab.robots.FrameWaypoints`, this class allows for specifying a targets where the rotation
+:class:`~compas_fab.robots.FrameWaypoints`, this class allows for specifying targets where the rotation
 around the Z-axis is not fixed. This is useful for example when the robot is using a cylindrical tool
 to perform a task, for example 3D printing, welding or drilling. The freely rotating axis is defined relative
 to the Z-axis of the tool coordinate frame (TCF). Note that the orientation of the tool

--- a/docs/examples/03_backends_ros/files/04_plan_cartesian_motion.py
+++ b/docs/examples/03_backends_ros/files/04_plan_cartesian_motion.py
@@ -1,25 +1,25 @@
 from compas.geometry import Frame
 
 from compas_fab.backends import RosClient
+from compas_fab.robots import FrameWaypoints
 
 with RosClient() as client:
     robot = client.load_robot()
-    assert robot.name == 'ur5_robot'
+    assert robot.name == "ur5_robot"
 
     frames = []
     frames.append(Frame([0.3, 0.1, 0.5], [1, 0, 0], [0, 1, 0]))
     frames.append(Frame([0.5, 0.1, 0.6], [1, 0, 0], [0, 1, 0]))
+    waypoints = FrameWaypoints(frames)
 
     start_configuration = robot.zero_configuration()
     start_configuration.joint_values = (-0.042, 0.033, -2.174, 5.282, -1.528, 0.000)
     options = {
-        'max_step': 0.01,
-        'avoid_collisions': True,
+        "max_step": 0.01,
+        "avoid_collisions": True,
     }
 
-    trajectory = robot.plan_cartesian_motion(frames,
-                                             start_configuration,
-                                             options=options)
+    trajectory = robot.plan_cartesian_motion(waypoints, start_configuration, options=options)
 
     print("Computed cartesian path with %d configurations, " % len(trajectory.points))
     print("following %d%% of requested trajectory." % (trajectory.fraction * 100))

--- a/docs/examples/03_backends_ros/files/gh_plan_cartesian_motion.py
+++ b/docs/examples/03_backends_ros/files/gh_plan_cartesian_motion.py
@@ -22,11 +22,12 @@
         :class:`compas_fab.robots.JointTrajectory`
             The calculated trajectory.
 """
+
 from __future__ import print_function
 import scriptcontext as sc
 
 from compas.geometry import Frame
-
+from compas_fab.robots import FrameWaypoints
 
 guid = str(ghenv.Component.InstanceGuid)
 response_key = "response_" + guid
@@ -38,14 +39,14 @@ frames = [Frame(plane.Origin, plane.XAxis, plane.YAxis) for plane in planes]
 if robot and robot.client and start_configuration and compute:
     if robot.client.is_connected:
         options = {
-            'max_step': float(max_step),
-            'avoid_collisions': bool(avoid_collisions),
-            'attached_collision_meshes': list(attached_colllision_meshes),
+            "max_step": float(max_step),
+            "avoid_collisions": bool(avoid_collisions),
+            "attached_collision_meshes": list(attached_colllision_meshes),
         }
-        sc.sticky[response_key] = robot.plan_cartesian_motion(frames,
-                                                              start_configuration=start_configuration,
-                                                              group=group,
-                                                              options=options)
+        waypoints = FrameWaypoints(frames)
+        sc.sticky[response_key] = robot.plan_cartesian_motion(
+            waypoints, start_configuration=start_configuration, group=group, options=options
+        )
     else:
         print("Robot client is not connected")
 

--- a/docs/examples/06_backends_kinematics/files/04_cartesian_path_analytic_pybullet.py
+++ b/docs/examples/06_backends_kinematics/files/04_cartesian_path_analytic_pybullet.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 from compas.geometry import Frame
 
 from compas_fab.backends import AnalyticalPyBulletClient
+from compas_fab.robots import FrameWaypoints
 
 frames_WCF = [
     Frame((0.407, 0.073, 0.320), (0.922, 0.000, 0.388), (0.113, 0.956, -0.269)),
@@ -16,7 +17,8 @@ with AnalyticalPyBulletClient(connection_type="direct") as client:
 
     options = {"solver": "ur5", "check_collision": True}
     start_configuration = list(robot.iter_inverse_kinematics(frames_WCF[0], options=options))[-1]
-    trajectory = robot.plan_cartesian_motion(frames_WCF, start_configuration=start_configuration, options=options)
+    waypoints = FrameWaypoints(frames_WCF)
+    trajectory = robot.plan_cartesian_motion(waypoints, start_configuration=start_configuration, options=options)
     assert trajectory.fraction == 1.0
 
     j = [c.joint_values for c in trajectory.points]

--- a/src/compas_fab/backends/interfaces/backend_features.py
+++ b/src/compas_fab/backends/interfaces/backend_features.py
@@ -125,18 +125,18 @@ class PlanCartesianMotion(object):
     <https://en.wikipedia.org/wiki/Function_object#In_Python>.
     """
 
-    def __call__(self, robot, frames_WCF, start_configuration=None, group=None, options=None):
-        return self.plan_cartesian_motion(robot, frames_WCF, start_configuration, group, options)
+    def __call__(self, robot, waypoints, start_configuration=None, group=None, options=None):
+        return self.plan_cartesian_motion(robot, waypoints, start_configuration, group, options)
 
-    def plan_cartesian_motion(self, robot, frames_WCF, start_configuration=None, group=None, options=None):
+    def plan_cartesian_motion(self, robot, waypoints, start_configuration=None, group=None, options=None):
         """Calculates a cartesian motion path (linear in tool space).
 
         Parameters
         ----------
         robot : :class:`compas_fab.robots.Robot`
             The robot instance for which the cartesian motion path is being calculated.
-        frames_WCF: list of :class:`compas.geometry.Frame`
-            The frames through which the path is defined.
+        waypoints : :class:`compas_fab.robots.Waypoints`
+            The waypoints for the robot to follow.
         start_configuration: :class:`compas_robots.Configuration`, optional
             The robot's full configuration, i.e. values for all configurable
             joints of the entire robot, at the starting position.

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -1,6 +1,5 @@
 import math
 
-import compas
 from compas.geometry import argmin
 
 from compas_fab.backends.interfaces import PlanCartesianMotion

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -34,8 +34,7 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
         group : str, optional
             The planning group used for calculation.
         options : dict, optional
-            Dictionary containing kwargs for arguments specific to
-            the client being queried.
+            Dictionary containing the key-value pairs that are passed to :func:`compas_fab.robots.Robot.iter_inverse_kinematics`
 
         Returns
         -------

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -1,5 +1,6 @@
 import math
 
+import compas
 from compas.geometry import argmin
 
 from compas_fab.backends.interfaces import PlanCartesianMotion
@@ -12,12 +13,13 @@ from compas_fab.robots import PointAxisWaypoints
 
 from compas_fab.utilities import from_tcf_to_t0cf
 
-from typing import TYPE_CHECKING
+if not compas.IPY:
+    from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from typing import Optional  # noqa: F401
-    from compas_fab.robots import Robot  # noqa: F401
-    from compas_robots import Configuration  # noqa: F401
+    if TYPE_CHECKING:
+        from typing import Optional  # noqa: F401
+        from compas_fab.robots import Robot  # noqa: F401
+        from compas_robots import Configuration  # noqa: F401
 
 
 class AnalyticalPlanCartesianMotion(PlanCartesianMotion):

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -12,6 +12,13 @@ from compas_fab.robots import PointAxisWaypoints
 
 from compas_fab.utilities import from_tcf_to_t0cf
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional  # noqa: F401
+    from compas_fab.robots import Robot  # noqa: F401
+    from compas_robots import Configuration  # noqa: F401
+
 
 class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     """ """
@@ -60,6 +67,7 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     def _plan_cartesian_motion_with_frame_waypoints(
         self, robot, waypoints, start_configuration=None, group=None, options=None
     ):
+        # type: (Robot, FrameWaypoints, Optional[Configuration], Optional[str], Optional[dict]) -> JointTrajectory
         """Calculates a cartesian motion path with frame waypoints.
 
         Planner behavior:
@@ -69,7 +77,9 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
         """
         # convert the target frames to the robot's base frame
         if waypoints.tool_coordinate_frame is not None:
-            frames_WCF = [from_tcf_to_t0cf(frame, waypoints.tool_coordinate_frame) for frame in waypoints.frames]
+            frames_WCF = [from_tcf_to_t0cf(frame, waypoints.tool_coordinate_frame) for frame in waypoints.target_frames]
+        else:
+            frames_WCF = waypoints.target_frames
 
         # convert the frame WCF to RCF
         base_frame = robot.get_base_frame(group=group, full_configuration=start_configuration)
@@ -114,7 +124,8 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     def _plan_cartesian_motion_with_point_axis_waypoints(
         self, robot, waypoints, start_configuration=None, group=None, options=None
     ):
-
+        # type: (Robot, PointAxisWaypoints, Optional[Configuration], Optional[str], Optional[dict]) -> JointTrajectory
+        """Planning Cartesian motion with PointAxisWaypoints is not yet implemented in the Analytical backend."""
         raise NotImplementedError(
             "Planning Cartesian motion with PointAxisWaypoints is not yet implemented in the Analytical backend."
         )

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -10,6 +10,7 @@ from compas_fab.robots import JointTrajectory
 from compas_fab.robots import JointTrajectoryPoint
 from compas_fab.robots import FrameWaypoints
 from compas_fab.robots import PointAxisWaypoints
+from compas_fab.utilities import from_tcf_to_t0cf
 
 
 class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
@@ -64,7 +65,7 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
         Planner behavior:
         - If multiple paths are possible (i.e. due to multiple IK results), only the one that is closest to the start_configuration is returned.
         - The path is checked to ensure that the joint values are continuous and that revolution values are the smallest possible.
-        - 'stepsize' is not used to sample in between frames (i.e. no interpolation), only the input frames are used.
+        - There is no interpolation in between frames (i.e. 'max_step' parameter is not supported), only the input frames are used.
         """
         # convert the target frames to the robot's base frame
         if waypoints.tool_coordinate_frame is not None:
@@ -86,8 +87,13 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
             configurations = list(robot.iter_inverse_kinematics(frame, options=options))
             configurations_along_path.append(configurations)
 
-        # There is a maximum of 8 possible paths, corresponding to the 8 possible IK solutions for each frame
-        # The all() function is used to check if all configurations in a path are present.
+        # Analytical backend only supports robots with finite IK solutions
+        # For 6R articulated robots, there is a maximum of 8 possible paths, corresponding to the 8 possible IK solutions for each frame
+        # The `options.update({"keep_order": True})` ensures that the order of the configurations is the same across all frames
+        # but this also cause some configurations to be None, if no solution was found.
+
+        # The `all(configurations)` below is used to check if all configurations in a path are present.
+        # indicating that a complete trajectory was found.
         paths = []
         for configurations in zip(*configurations_along_path):
             if all(configurations):

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -11,16 +11,6 @@ from compas_fab.robots import JointTrajectoryPoint
 from compas_fab.robots import FrameWaypoints
 from compas_fab.robots import PointAxisWaypoints
 
-from compas_fab.utilities import from_tcf_to_t0cf
-
-if not compas.IPY:
-    from typing import TYPE_CHECKING
-
-    if TYPE_CHECKING:
-        from typing import Optional  # noqa: F401
-        from compas_fab.robots import Robot  # noqa: F401
-        from compas_robots import Configuration  # noqa: F401
-
 
 class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     """ """
@@ -69,7 +59,6 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     def _plan_cartesian_motion_with_frame_waypoints(
         self, robot, waypoints, start_configuration=None, group=None, options=None
     ):
-        # type: (Robot, FrameWaypoints, Optional[Configuration], Optional[str], Optional[dict]) -> JointTrajectory
         """Calculates a cartesian motion path with frame waypoints.
 
         Planner behavior:
@@ -115,9 +104,8 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
         path = paths[idx]
         path = self.smooth_configurations(path)
         trajectory = JointTrajectory()
-        trajectory.fraction = len(path) / len(
-            frames_RCF
-        )  # Technically this always be 1.0 because otherwise, the path would be rejected earlier
+        trajectory.fraction = len(path) / len(frames_RCF)
+        # Technically trajectory.fraction should always be 1.0 because otherwise, the path would be rejected earlier
         trajectory.joint_names = path[0].joint_names
         trajectory.points = [JointTrajectoryPoint(config.joint_values, config.joint_types) for config in path]
         trajectory.start_configuration = robot.merge_group_with_full_configuration(path[0], start_configuration, group)
@@ -126,7 +114,6 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     def _plan_cartesian_motion_with_point_axis_waypoints(
         self, robot, waypoints, start_configuration=None, group=None, options=None
     ):
-        # type: (Robot, PointAxisWaypoints, Optional[Configuration], Optional[str], Optional[dict]) -> JointTrajectory
         """Planning Cartesian motion with PointAxisWaypoints is not yet implemented in the Analytical backend."""
         raise NotImplementedError(
             "Planning Cartesian motion with PointAxisWaypoints is not yet implemented in the Analytical backend."

--- a/src/compas_fab/ghpython/components/Cf_PlanCartesianMotion/code.py
+++ b/src/compas_fab/ghpython/components/Cf_PlanCartesianMotion/code.py
@@ -9,6 +9,7 @@ from ghpythonlib.componentbase import executingcomponent as component
 from scriptcontext import sticky as st
 
 from compas_fab.ghpython.components import create_id
+from compas_fab.robots import FrameWaypoints
 
 
 class PlanCartesianMotion(component):
@@ -23,8 +24,9 @@ class PlanCartesianMotion(component):
 
         if robot and robot.client and robot.client.is_connected and start_configuration and planes and compute:
             frames = [plane_to_compas_frame(plane) for plane in planes]
+            frame_waypoints = FrameWaypoints(frames)
             st[key] = robot.plan_cartesian_motion(
-                frames,
+                frame_waypoints,
                 start_configuration=start_configuration,
                 group=group,
                 options=dict(

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1415,9 +1415,7 @@ class Robot(Data):
                 else:
                     cp.scale(1.0 / self.scale_factor)
                 path_constraints_WCF_scaled.append(cp)
-        else:
-            path_constraints_WCF_scaled = None
-        options["path_constraints"] = path_constraints_WCF_scaled
+            options["path_constraints"] = path_constraints_WCF_scaled
 
         # =====================
         # Attached CM and Tools

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1321,8 +1321,9 @@ class Robot(Data):
         ----------
         waypoints : :class:`compas_fab.robots.Waypoints`
             The waypoints for the robot to follow.
-            If a tool is attached to the robot, the :meth:`~compas_fab.robots.Waypoints.tool_coordinate_frame` parameter
-            should be set.
+            For more information on how to define waypoints, see :ref:`waypoints`.
+            In addition, note that not all planning backends support all waypoint types,
+            check documentation of the backend in use for more details.
         start_configuration : :class:`compas_robots.Configuration`, optional
             The robot's full configuration, i.e. values for all configurable
             joints of the entire robot, at the start of the motion.

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1374,8 +1374,9 @@ class Robot(Data):
         True
         """
         # The plan_cartesian_motion method in the Robot class is a wrapper around planing backend's
-        # plan_cartesian_motion method. This method is responsible for scaling the waypoints, start_configuration,
-        # options and the planned trajectory.
+        # plan_cartesian_motion method. This method is responsible for scaling the waypoints, start_configuration and the planned trajectory.
+        # Some options may also need scaling, like max_step. This should be removed in the future.
+        # TODO: Discuss if we can have all options passed with a fixed unit to avoid scaling.
         # Attached tools are also managed by this function.
 
         options = options or {}

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -497,6 +497,8 @@ class Waypoints(Data):
     ----------
     name : str , optional, default = 'target'
         A human-readable name for identifying the target.
+    tool_coordinate_frame : :class:`compas.geometry.Frame` or :class:`compas.geometry.Transformation`
+        The tool tip coordinate frame relative to the flange of the robot.
 
     See Also
     --------
@@ -509,7 +511,7 @@ class Waypoints(Data):
         self.name = name
 
     @property
-    def __data__(self):
+    def tool_coordinate_frame(self):
         raise NotImplementedError
 
     def scaled(self, factor):
@@ -687,6 +689,8 @@ class PointAxisWaypoints(Waypoints):
         super(PointAxisWaypoints, self).__init__(name=name)
         self.target_points_and_axes = target_points_and_axes
         self.tolerance_position = tolerance_position
+        if isinstance(tool_coordinate_frame, Transformation):
+            tool_coordinate_frame = Frame.from_transformation(tool_coordinate_frame)
         self.tool_coordinate_frame = tool_coordinate_frame
 
     @property

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -3,6 +3,12 @@ from compas.geometry import Frame
 from compas.geometry import Transformation
 from compas_robots.model import Joint
 
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from compas_robots import Configuration  # noqa: F401
+
 __all__ = [
     "Target",
     "FrameTarget",
@@ -230,7 +236,7 @@ class PointAxisTarget(Target):
         The tool tip coordinate frame relative to the flange coordinate frame of the robot.
         If not specified, the target point is relative to the robot's flange (T0CF) and the
         Z axis of the flange can rotate around the target axis.
-    nane : str, optional
+    name : str, optional
         The human-readable name of the target.
         Defaults to 'Point-Axis Target'.
     """
@@ -497,7 +503,7 @@ class Waypoints(Data):
     ----------
     name : str , optional, default = 'target'
         A human-readable name for identifying the target.
-    tool_coordinate_frame : :class:`compas.geometry.Frame` or :class:`compas.geometry.Transformation`
+    tool_coordinate_frame : :class:`compas.geometry.Frame` or :class:`compas.geometry.Transformation`, optional
         The tool tip coordinate frame relative to the flange of the robot.
 
     See Also
@@ -509,6 +515,9 @@ class Waypoints(Data):
     def __init__(self, tool_coordinate_frame, name="Generic Waypoints"):
         super(Waypoints, self).__init__()
         self.name = name
+        # If the user provides a transformation, convert it to a Frame
+        if isinstance(tool_coordinate_frame, Transformation):
+            tool_coordinate_frame = Frame.from_transformation(tool_coordinate_frame)
         self.tool_coordinate_frame = tool_coordinate_frame
 
     def scaled(self, factor):
@@ -566,13 +575,10 @@ class FrameWaypoints(Waypoints):
         tool_coordinate_frame=None,
         name="Frame Waypoints",
     ):
-        super(FrameWaypoints, self).__init__(name=name)
+        super(FrameWaypoints, self).__init__(tool_coordinate_frame=tool_coordinate_frame, name=name)
         self.target_frames = target_frames
         self.tolerance_position = tolerance_position
         self.tolerance_orientation = tolerance_orientation
-        if isinstance(tool_coordinate_frame, Transformation):
-            tool_coordinate_frame = Frame.from_transformation(tool_coordinate_frame)
-        self.tool_coordinate_frame = tool_coordinate_frame
 
     @property
     def __data__(self):
@@ -666,7 +672,7 @@ class PointAxisWaypoints(Waypoints):
     tolerance_position : float, optional
         The tolerance for the position of the target point.
         If not specified, the default value from the planner is used.
-    tool_coordinate_frame : :class:`compas.geometry.Frame`, optional
+    tool_coordinate_frame : :class:`compas.geometry.Frame` or :class:`compas.geometry.Transformation`, optional
         The tool tip coordinate frame relative to the flange coordinate frame of the robot.
         If not specified, the target point is relative to the robot's flange (T0CF) and the
         Z axis of the flange can rotate around the target axis.
@@ -683,12 +689,9 @@ class PointAxisWaypoints(Waypoints):
         tool_coordinate_frame=None,
         name="Point-Axis Waypoints",
     ):
-        super(PointAxisWaypoints, self).__init__(name=name)
+        super(PointAxisWaypoints, self).__init__(tool_coordinate_frame=tool_coordinate_frame, name=name)
         self.target_points_and_axes = target_points_and_axes
         self.tolerance_position = tolerance_position
-        if isinstance(tool_coordinate_frame, Transformation):
-            tool_coordinate_frame = Frame.from_transformation(tool_coordinate_frame)
-        self.tool_coordinate_frame = tool_coordinate_frame
 
     @property
     def __data__(self):

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -5,12 +5,6 @@ from compas.geometry import Frame
 from compas.geometry import Transformation
 from compas_robots.model import Joint
 
-if not compas.IPY:
-    from typing import TYPE_CHECKING
-
-    if TYPE_CHECKING:
-        from compas_robots import Configuration  # noqa: F401
-
 __all__ = [
     "Target",
     "FrameTarget",
@@ -190,7 +184,7 @@ class FrameTarget(Target):
         """
         target_frame = self.target_frame.scaled(factor)
         tolerance_position = self.tolerance_position * factor
-        tolerance_orientation = self.tolerance_orientation * factor
+        tolerance_orientation = self.tolerance_orientation
         tool_coordinate_frame = self.tool_coordinate_frame.scaled(factor) if self.tool_coordinate_frame else None
         return FrameTarget(target_frame, tolerance_position, tolerance_orientation, tool_coordinate_frame, self.name)
 

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -30,9 +30,9 @@ class Target(Data):
     pose, configuration, and joint constraints. Dynamic targets such as
     velocity, acceleration, and jerk are not yet supported.
 
-    Waypoints are intended to be used for motion planning with a planning backend by using :meth:`compas_fab.robot.plan_motion`.
-    Different backends might support different types of
-    targets.
+    Targets are intended to be used for motion planning with a planning backend
+    by using :meth:`compas_fab.robot.plan_motion`.
+    Note that different backends support different types of targets.
 
     Attributes
     ----------
@@ -497,8 +497,8 @@ class Waypoints(Data):
     Waypoints are useful for tasks like painting, welding, or 3D printing, where the programmer
     wants to define the waypoints the robot should pass through.
 
-    Waypoints are intended to be used for motion planning with a planning backend by using :meth:`compas_fab.robot.plan_motion_with_waypoints`.
-    Different backends might support different types of waypoints.
+    Waypoints are intended to be used for motion planning with a planning backend by using :meth:`compas_fab.robot.plan_cartesian_motion`.
+    Note that different backends support different types of waypoints.
     The method of interpolation between the waypoints is controlled by the motion planner backend.
 
     Attributes

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -1,5 +1,3 @@
-import compas
-
 from compas.data import Data
 from compas.geometry import Frame
 from compas.geometry import Transformation

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -1,13 +1,15 @@
+import compas
+
 from compas.data import Data
 from compas.geometry import Frame
 from compas.geometry import Transformation
 from compas_robots.model import Joint
 
+if not compas.IPY:
+    from typing import TYPE_CHECKING
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from compas_robots import Configuration  # noqa: F401
+    if TYPE_CHECKING:
+        from compas_robots import Configuration  # noqa: F401
 
 __all__ = [
     "Target",

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -506,13 +506,10 @@ class Waypoints(Data):
     :class:`FrameWaypoints`
     """
 
-    def __init__(self, name="Generic Waypoints"):
+    def __init__(self, tool_coordinate_frame, name="Generic Waypoints"):
         super(Waypoints, self).__init__()
         self.name = name
-
-    @property
-    def tool_coordinate_frame(self):
-        raise NotImplementedError
+        self.tool_coordinate_frame = tool_coordinate_frame
 
     def scaled(self, factor):
         """Returns a scaled copy of the waypoints.

--- a/tests/backends/kinematics/test_inverse_kinematics.py
+++ b/tests/backends/kinematics/test_inverse_kinematics.py
@@ -150,4 +150,6 @@ def test_kinematics_cartesian_with_tool_coordinate_frame(frame_waypoints):
         # Assert that the trajectory is complete
         assert trajectory.fraction == 1.0
         # Assert that the trajectory has the correct number of points
+        # NOTE: At the moment the AnalyticalPyBulletClient does not perform any interpolation between frames
+        # NOTE: if future implementation fixes this, the following test will not be valid anymore
         assert len(trajectory.points) == len(frame_waypoints.target_frames)

--- a/tests/robots/test_targets.py
+++ b/tests/robots/test_targets.py
@@ -172,7 +172,7 @@ def test_target_scale(frame_target):
     nt = frame_target.scaled(scale_factor)
     assert nt.target_frame == frame_target.target_frame.scaled(scale_factor)
     assert nt.tolerance_position == frame_target.tolerance_position * scale_factor
-    assert nt.tolerance_orientation == frame_target.tolerance_orientation * scale_factor
+    assert nt.tolerance_orientation == frame_target.tolerance_orientation
     assert nt.tool_coordinate_frame == frame_target.tool_coordinate_frame.scaled(scale_factor)
 
 


### PR DESCRIPTION
This is a short PR to migrate the plan_cartrsian_motion to use Waypoints class.

At the moment, only the FrameWaypoints are supported as no implementation is added for PointAxisWaypoints yet. Will do that in next PR.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [] New feature in a **backwards-compatible** manner.
- [x] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
