### PR TITLE
Backend planners now use multi-inherence instead of `__call__` to include the backend functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Backend planners now use multi-inherence instead of `__call__` to include the backend functions. This allows for better generated documentation.
 * `Robot.plan_carteisan_motion()` now accepts `Waypoints` as target. Implementation for `FrameWaypoints` is supported with same functionality as before. Simply wrap `Frame` objects using `FrameWaypoints(frames)`.
 * Changed `BoundingVolume`, `Constraint`, `JointConstraint`, `OrientationConstraint`, `PositionConstraint` to inherit from `compas.data.Data` class.
 * Change the signature of `plan_motion()` to use `target` (`Target` class) instead of `goal_constraints`. Only one target is accepted. Users who wish to compose their own constraint sets can still use `ConstraintSetTarget`.

--- a/docs/developer/backends.rst
+++ b/docs/developer/backends.rst
@@ -82,3 +82,15 @@ Backend interfaces
 ==================
 
 .. automodule:: compas_fab.backends.interfaces
+
+Implemented backend features
+============================
+
+The following backend features are implemented for the ROS backend:
+
+.. automodule:: compas_fab.backends.ros.backend_features
+
+The following backend features are implemented for the PyBullet backend:
+
+.. automodule:: compas_fab.backends.pybullet.backend_features
+

--- a/src/compas_fab/backends/interfaces/__init__.py
+++ b/src/compas_fab/backends/interfaces/__init__.py
@@ -21,6 +21,7 @@ Feature interfaces
     :toctree: generated/
     :nosignatures:
 
+    BackendFeature
     ForwardKinematics
     InverseKinematics
     PlanMotion

--- a/src/compas_fab/backends/interfaces/__init__.py
+++ b/src/compas_fab/backends/interfaces/__init__.py
@@ -46,6 +46,7 @@ Planning scene interfaces
 from .backend_features import AddAttachedCollisionMesh
 from .backend_features import AddCollisionMesh
 from .backend_features import AppendCollisionMesh
+from .backend_features import BackendFeature
 from .backend_features import ForwardKinematics
 from .backend_features import GetPlanningScene
 from .backend_features import InverseKinematics
@@ -58,17 +59,18 @@ from .client import ClientInterface
 from .client import PlannerInterface
 
 __all__ = [
-    "ForwardKinematics",
-    "InverseKinematics",
-    "PlanMotion",
-    "PlanCartesianMotion",
-    "GetPlanningScene",
+    "AddAttachedCollisionMesh",
     "AddCollisionMesh",
     "AppendCollisionMesh",
+    "BackendFeature",
+    "ClientInterface",
+    "ForwardKinematics",
+    "GetPlanningScene",
+    "InverseKinematics",
+    "PlanCartesianMotion",
+    "PlanMotion",
+    "PlannerInterface",
     "RemoveCollisionMesh",
-    "AddAttachedCollisionMesh",
     "RemoveAttachedCollisionMesh",
     "ResetPlanningScene",
-    "ClientInterface",
-    "PlannerInterface",
 ]

--- a/src/compas_fab/backends/interfaces/backend_features.py
+++ b/src/compas_fab/backends/interfaces/backend_features.py
@@ -2,18 +2,32 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import compas
 
-class ForwardKinematics(object):
-    """Interface for a Planner's forward kinematics feature.  Any implementation of
-    ``ForwardKinematics`` must define the method ``forward_kinematics``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``ForwardKinematics`` to be treated as its ``forward_kinematics`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
+if not compas.IPY:
+    from typing import TYPE_CHECKING
 
-    def __call__(self, robot, configuration, group=None, options=None):
-        return self.forward_kinematics(robot, configuration, group, options)
+    if TYPE_CHECKING:
+        from compas_fab.backends.interfaces import ClientInterface  # noqa: F401
+
+
+class BackendFeature(object):
+    """Base class for all backend features that are implemented by a backend client."""
+
+    def __init__(self, client):
+        # All backend features are assumed to be associated with a backend client.
+        self.client = client  # type: ClientInterface
+
+
+#   The code that contains the actual feature implementation is located in the backend's module.
+#   For example, the features for moveit planner and ros client are located in :
+#   "src/compas_fab/backends/ros/backend_features/"
+#   If you cannot a specific feature in the 'backend_features', it means that the planner
+#   does not support that feature.
+
+
+class ForwardKinematics(BackendFeature):
+    """Mix-in interface for implementing a planner's forward kinematics feature."""
 
     def forward_kinematics(self, robot, configuration, group=None, options=None):
         """Calculate the robot's forward kinematic.
@@ -40,17 +54,8 @@ class ForwardKinematics(object):
         pass
 
 
-class InverseKinematics(object):
-    """Interface for a Planner's inverse kinematics feature.  Any implementation of
-    ``InverseKinematics`` must define the method ``inverse_kinematics``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``InverseKinematics`` to be treated as its ``inverse_kinematics`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
-        return self.inverse_kinematics(robot, frame_WCF, start_configuration, group, options)
+class InverseKinematics(BackendFeature):
+    """Mix-in interface for implementing a planner's inverse kinematics feature."""
 
     def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
         """Calculate the robot's inverse kinematic for a given frame.
@@ -78,17 +83,8 @@ class InverseKinematics(object):
         pass
 
 
-class PlanMotion(object):
-    """Interface for a Planner's plan motion feature.  Any implementation of
-    ``PlanMotion`` must define the method ``plan_motion``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``PlanMotion`` to be treated as its ``plan_motion`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, robot, target, start_configuration=None, group=None, options=None):
-        return self.plan_motion(robot, target, start_configuration, group, options)
+class PlanMotion(BackendFeature):
+    """Mix-in interface for implementing a planner's plan motion feature."""
 
     def plan_motion(self, robot, target, start_configuration=None, group=None, options=None):
         """Calculates a motion path.
@@ -116,17 +112,8 @@ class PlanMotion(object):
         pass
 
 
-class PlanCartesianMotion(object):
-    """Interface for a Planner's plan cartesian motion feature.  Any implementation of
-    ``PlanCartesianMotion`` must define the method ``plan_cartesian_motion``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``PlanCartesianMotion`` to be treated as its ``plan_cartesian_motion`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, robot, waypoints, start_configuration=None, group=None, options=None):
-        return self.plan_cartesian_motion(robot, waypoints, start_configuration, group, options)
+class PlanCartesianMotion(BackendFeature):
+    """Mix-in interface for implementing a planner's plan cartesian motion feature."""
 
     def plan_cartesian_motion(self, robot, waypoints, start_configuration=None, group=None, options=None):
         """Calculates a cartesian motion path (linear in tool space).
@@ -154,17 +141,8 @@ class PlanCartesianMotion(object):
         pass
 
 
-class GetPlanningScene(object):
-    """Interface for a Planner's get planning scene feature.  Any implementation of
-    ``GetPlanningScene`` must define the method ``get_planning_scene``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``GetPlanningScene`` to be treated as its ``get_planning_scene`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, options=None):
-        return self.get_planning_scene(options)
+class GetPlanningScene(BackendFeature):
+    """Mix-in interface for implementing a planner's get planning scene feature."""
 
     def get_planning_scene(self, options=None):
         """Retrieve the planning scene.
@@ -182,20 +160,11 @@ class GetPlanningScene(object):
         pass
 
 
-class ResetPlanningScene(object):
-    """Interface for a Planner's reset planning scene feature.  Any implementation of
-    ``ResetPlanningScene`` must define the method ``reset_planning_scene``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``ResetPlanningScene`` to be treated as its ``reset_planning_scene`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, options=None):
-        return self.reset_planning_scene(options)
+class ResetPlanningScene(BackendFeature):
+    """Mix-in interface for implementing a planner's reset planning scene feature."""
 
     def reset_planning_scene(self, options=None):
-        """Retrieve the planning scene.
+        """Resets the planning scene, removing all added collision meshes.
 
         Parameters
         ----------
@@ -210,17 +179,8 @@ class ResetPlanningScene(object):
         pass
 
 
-class AddCollisionMesh(object):
-    """Interface for a Planner's add collision mesh feature.  Any implementation of
-    ``AddCollisionMesh`` must define the method ``add_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``AddCollisionMesh`` to be treated as its ``add_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, collision_mesh, options=None):
-        return self.add_collision_mesh(collision_mesh, options)
+class AddCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's add collision mesh feature."""
 
     def add_collision_mesh(self, collision_mesh, options=None):
         """Add a collision mesh to the planning scene.
@@ -240,17 +200,8 @@ class AddCollisionMesh(object):
         pass
 
 
-class RemoveCollisionMesh(object):
-    """Interface for a Planner's remove collision mesh feature.  Any implementation of
-    ``RemoveCollisionMesh`` must define the method ``remove_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``RemoveCollisionMesh`` to be treated as its ``remove_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, id, options=None):
-        return self.remove_collision_mesh(id, options)
+class RemoveCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's remove collision mesh feature."""
 
     def remove_collision_mesh(self, id, options=None):
         """Remove a collision mesh from the planning scene.
@@ -270,17 +221,8 @@ class RemoveCollisionMesh(object):
         pass
 
 
-class AppendCollisionMesh(object):
-    """Interface for a Planner's append collision mesh feature.  Any implementation of
-    ``AppendCollisionMesh`` must define the method ``append_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``AppendCollisionMesh`` to be treated as its ``append_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, collision_mesh, options=None):
-        return self.append_collision_mesh(collision_mesh, options)
+class AppendCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's append collision mesh feature."""
 
     def append_collision_mesh(self, collision_mesh, options=None):
         """Append a collision mesh to the planning scene.
@@ -300,17 +242,8 @@ class AppendCollisionMesh(object):
         pass
 
 
-class AddAttachedCollisionMesh(object):
-    """Interface for a Planner's add attached collision mesh feature.  Any implementation of
-    ``AddAttachedCollisionMesh`` must define the method ``add_attached_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``AddAttachedCollisionMesh`` to be treated as its ``add_attached_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, attached_collision_mesh, options=None):
-        return self.add_attached_collision_mesh(attached_collision_mesh, options)
+class AddAttachedCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's add attached collision mesh feature."""
 
     def add_attached_collision_mesh(self, attached_collision_mesh, options=None):
         """Add a collision mesh and attach it to the robot.
@@ -330,17 +263,8 @@ class AddAttachedCollisionMesh(object):
         pass
 
 
-class RemoveAttachedCollisionMesh(object):
-    """Interface for a Planner's remove attached collision mesh feature.  Any implementation of
-    ``RemoveAttachedCollisionMesh`` must define the method ``remove_attached_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``RemoveAttachedCollisionMesh`` to be treated as its ``remove_attached_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, id, options=None):
-        return self.remove_attached_collision_mesh(id, options)
+class RemoveAttachedCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's remove attached collision mesh feature."""
 
     def remove_attached_collision_mesh(self, id, options=None):
         """Remove an attached collision mesh from the robot.

--- a/src/compas_fab/backends/interfaces/backend_features.py
+++ b/src/compas_fab/backends/interfaces/backend_features.py
@@ -12,7 +12,14 @@ if not compas.IPY:
 
 
 class BackendFeature(object):
-    """Base class for all backend features that are implemented by a backend client."""
+    """Base class for all backend features that are implemented by a backend client.
+
+    Attributes
+    ----------
+    client : :class:`compas_fab.backends.interfaces.ClientInterface`
+        The backend client that supports this feature.
+
+    """
 
     def __init__(self, client):
         # All backend features are assumed to be associated with a backend client.
@@ -36,7 +43,7 @@ class ForwardKinematics(BackendFeature):
         ----------
         robot : :class:`compas_fab.robots.Robot`
             The robot instance for which forward kinematics is being calculated.
-        configuration : :class:`compas_fab.robots.Configuration`
+        configuration : :class:`compas_robots.Configuration`
             The full configuration to calculate the forward kinematic for. If no
             full configuration is passed, the zero-joint state for the other
             configurable joints is assumed.
@@ -53,6 +60,9 @@ class ForwardKinematics(BackendFeature):
         """
         pass
 
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_forward_kinematics.py"
+
 
 class InverseKinematics(BackendFeature):
     """Mix-in interface for implementing a planner's inverse kinematics feature."""
@@ -66,12 +76,12 @@ class InverseKinematics(BackendFeature):
         ----------
         robot : :class:`compas_fab.robots.Robot`
             The robot instance for which inverse kinematics is being calculated.
-        frame_WCF: :class:`compas.geometry.Frame`
+        frame_WCF : :class:`compas.geometry.Frame`
             The frame to calculate the inverse for.
-        start_configuration: :class:`compas_fab.robots.Configuration`, optional
-        group: str, optional
+        start_configuration : :class:`compas_robots.Configuration`, optional
+        group : str, optional
             The planning group used for calculation.
-        options: dict, optional
+        options : dict, optional
             Dictionary containing kwargs for arguments specific to
             the client being queried.
 
@@ -81,6 +91,9 @@ class InverseKinematics(BackendFeature):
             A tuple of 2 elements containing a list of joint positions and a list of matching joint names.
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_inverse_kinematics"
 
 
 class PlanMotion(BackendFeature):
@@ -93,12 +106,12 @@ class PlanMotion(BackendFeature):
         ----------
         robot : :class:`compas_fab.robots.Robot`
             The robot instance for which the motion path is being calculated.
-        target: :class:`compas_fab.robots.Target`
+        target : :class:`compas_fab.robots.Target`
             The goal for the robot to achieve.
-        start_configuration: :class:`compas_fab.robots.Configuration`, optional
+        start_configuration : :class:`compas_robots.Configuration`, optional
             The robot's full configuration, i.e. values for all configurable
             joints of the entire robot, at the starting position.
-        group: str, optional
+        group : str, optional
             The name of the group to plan for.
         options : dict, optional
             Dictionary containing kwargs for arguments specific to
@@ -110,6 +123,9 @@ class PlanMotion(BackendFeature):
             The calculated trajectory.
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_plan_motion.py"
 
 
 class PlanCartesianMotion(BackendFeature):
@@ -124,12 +140,12 @@ class PlanCartesianMotion(BackendFeature):
             The robot instance for which the cartesian motion path is being calculated.
         waypoints : :class:`compas_fab.robots.Waypoints`
             The waypoints for the robot to follow.
-        start_configuration: :class:`compas_robots.Configuration`, optional
+        start_configuration : :class:`compas_robots.Configuration`, optional
             The robot's full configuration, i.e. values for all configurable
             joints of the entire robot, at the starting position.
-        group: str, optional
+        group : str, optional
             The planning group used for calculation.
-        options: dict, optional
+        options : dict, optional
             Dictionary containing kwargs for arguments specific to
             the client being queried.
 
@@ -139,6 +155,9 @@ class PlanCartesianMotion(BackendFeature):
             The calculated trajectory.
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_plan_cartesian_motion.py"
 
 
 class GetPlanningScene(BackendFeature):
@@ -159,6 +178,9 @@ class GetPlanningScene(BackendFeature):
         """
         pass
 
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_get_planning_scene.py"
+
 
 class ResetPlanningScene(BackendFeature):
     """Mix-in interface for implementing a planner's reset planning scene feature."""
@@ -177,6 +199,9 @@ class ResetPlanningScene(BackendFeature):
         ``None``
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_reset_planning_scene.py"
 
 
 class AddCollisionMesh(BackendFeature):
@@ -198,6 +223,9 @@ class AddCollisionMesh(BackendFeature):
         ``None``
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_add_collision_mesh.py"
 
 
 class RemoveCollisionMesh(BackendFeature):
@@ -241,6 +269,9 @@ class AppendCollisionMesh(BackendFeature):
         """
         pass
 
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_append_collision_mesh.py"
+
 
 class AddAttachedCollisionMesh(BackendFeature):
     """Mix-in interface for implementing a planner's add attached collision mesh feature."""
@@ -262,6 +293,9 @@ class AddAttachedCollisionMesh(BackendFeature):
         """
         pass
 
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_add_attached_collision_mesh.py"
+
 
 class RemoveAttachedCollisionMesh(BackendFeature):
     """Mix-in interface for implementing a planner's remove attached collision mesh feature."""
@@ -282,3 +316,6 @@ class RemoveAttachedCollisionMesh(BackendFeature):
         ``None``
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_remove_attached_collision_mesh.py"

--- a/src/compas_fab/backends/interfaces/client.py
+++ b/src/compas_fab/backends/interfaces/client.py
@@ -106,7 +106,7 @@ class PlannerInterface(object):
     """
 
     def __init__(self, client):
-        super(PlannerInterface, self).__init__()
+        # super(PlannerInterface, self).__init__()
         self.client = client
 
     # ==========================================================================

--- a/src/compas_fab/backends/pybullet/backend_features/__init__.py
+++ b/src/compas_fab/backends/pybullet/backend_features/__init__.py
@@ -1,4 +1,25 @@
+"""
+PyBullet backend features
+=========================
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    PyBulletAddAttachedCollisionMesh
+    PyBulletAddCollisionMesh
+    PyBulletAppendCollisionMesh
+    PyBulletForwardKinematics
+    PyBulletInverseKinematics
+    PyBulletRemoveAttachedCollisionMesh
+    PyBulletRemoveCollisionMesh
+
+
+
+"""
+
 from __future__ import absolute_import
+
 
 from compas_fab.backends.pybullet.backend_features.pybullet_add_attached_collision_mesh import (
     PyBulletAddAttachedCollisionMesh,
@@ -17,8 +38,8 @@ __all__ = [
     "PyBulletAddAttachedCollisionMesh",
     "PyBulletAddCollisionMesh",
     "PyBulletAppendCollisionMesh",
-    "PyBulletRemoveCollisionMesh",
-    "PyBulletRemoveAttachedCollisionMesh",
     "PyBulletForwardKinematics",
     "PyBulletInverseKinematics",
+    "PyBulletRemoveAttachedCollisionMesh",
+    "PyBulletRemoveCollisionMesh",
 ]

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_add_attached_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_add_attached_collision_mesh.py
@@ -25,9 +25,6 @@ __all__ = [
 class PyBulletAddAttachedCollisionMesh(AddAttachedCollisionMesh):
     """Callable to add a collision mesh and attach it to the robot."""
 
-    def __init__(self, client):
-        self.client = client
-
     def add_attached_collision_mesh(self, attached_collision_mesh, options=None):
         """Add a collision mesh and attach it to the robot.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_add_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_add_collision_mesh.py
@@ -14,9 +14,6 @@ from compas_fab.backends.pybullet.const import STATIC_MASS
 class PyBulletAddCollisionMesh(AddCollisionMesh):
     """Callable to add a collision mesh to the planning scene."""
 
-    def __init__(self, client):
-        self.client = client
-
     def add_collision_mesh(self, collision_mesh, options=None):
         """Add a collision mesh to the planning scene.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_append_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_append_collision_mesh.py
@@ -12,9 +12,6 @@ __all__ = [
 class PyBulletAppendCollisionMesh(AppendCollisionMesh):
     """Callable to append a collision mesh to the planning scene."""
 
-    def __init__(self, client):
-        self.client = client
-
     def append_collision_mesh(self, collision_mesh, options=None):
         """Append a collision mesh to the planning scene.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
@@ -8,9 +8,6 @@ from compas_fab.backends.interfaces import ForwardKinematics
 class PyBulletForwardKinematics(ForwardKinematics):
     """Callable to calculate the robot's forward kinematic."""
 
-    def __init__(self, client):
-        self.client = client
-
     def forward_kinematics(self, robot, configuration, group=None, options=None):
         """Calculate the robot's forward kinematic.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -23,9 +23,6 @@ __all__ = [
 class PyBulletInverseKinematics(InverseKinematics):
     """Callable to calculate the robot's inverse kinematics for a given frame."""
 
-    def __init__(self, client):
-        self.client = client
-
     def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
         """Calculate the robot's inverse kinematic for a given frame.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_attached_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_attached_collision_mesh.py
@@ -16,9 +16,6 @@ __all__ = [
 class PyBulletRemoveAttachedCollisionMesh(RemoveAttachedCollisionMesh):
     """Callable to remove an attached collision mesh from the robot."""
 
-    def __init__(self, client):
-        self.client = client
-
     def remove_attached_collision_mesh(self, id, options=None):
         """Remove an attached collision mesh from the robot.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_collision_mesh.py
@@ -17,9 +17,6 @@ __all__ = [
 class PyBulletRemoveCollisionMesh(RemoveCollisionMesh):
     """Callable to remove a collision mesh from the planning scene."""
 
-    def __init__(self, client):
-        self.client = client
-
     def remove_collision_mesh(self, id, options=None):
         """Remove a collision mesh from the planning scene.
 

--- a/src/compas_fab/backends/pybullet/client.py
+++ b/src/compas_fab/backends/pybullet/client.py
@@ -827,8 +827,15 @@ class PyBulletClient(PyBulletBase, ClientInterface):
 
 
 class AnalyticalPyBulletClient(PyBulletClient):
-    def inverse_kinematics(self, *args, **kwargs):
-        return AnalyticalInverseKinematics(self)(*args, **kwargs)
+    """Combination of PyBullet as the client for COllision Detection and Analytical Inverse Kinematics."""
 
-    def plan_cartesian_motion(self, *args, **kwargs):
-        return AnalyticalPlanCartesianMotion(self)(*args, **kwargs)
+    def __init__(self, connection_type="gui", verbose=False):
+        PyBulletClient.__init__(self, connection_type=connection_type, verbose=verbose)
+
+    def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
+        planner = AnalyticalInverseKinematics(self)
+        return planner.inverse_kinematics(robot, frame_WCF, start_configuration, group, options)
+
+    def plan_cartesian_motion(self, robot, waypoints, start_configuration=None, group=None, options=None):
+        planner = AnalyticalPlanCartesianMotion(self)
+        return planner.plan_cartesian_motion(robot, waypoints, start_configuration, group, options)

--- a/src/compas_fab/backends/pybullet/planner.py
+++ b/src/compas_fab/backends/pybullet/planner.py
@@ -3,7 +3,8 @@ from __future__ import division
 from __future__ import print_function
 
 from compas_fab.backends.interfaces.client import PlannerInterface
-from compas_fab.backends.interfaces.client import forward_docstring
+
+# from compas_fab.backends.interfaces.client import forward_docstring
 from compas_fab.backends.pybullet.backend_features.pybullet_add_attached_collision_mesh import (
     PyBulletAddAttachedCollisionMesh,
 )
@@ -21,36 +22,17 @@ __all__ = [
 ]
 
 
-class PyBulletPlanner(PlannerInterface):
+class PyBulletPlanner(
+    PyBulletAddAttachedCollisionMesh,
+    PyBulletAddCollisionMesh,
+    PyBulletAppendCollisionMesh,
+    PyBulletRemoveCollisionMesh,
+    PyBulletRemoveAttachedCollisionMesh,
+    PyBulletForwardKinematics,
+    PyBulletInverseKinematics,
+    PlannerInterface,
+):
     """Implement the planner backend interface for PyBullet."""
 
     def __init__(self, client):
-        super(PyBulletPlanner, self).__init__(client)
-
-    @forward_docstring(PyBulletAddAttachedCollisionMesh)
-    def add_attached_collision_mesh(self, *args, **kwargs):
-        return PyBulletAddAttachedCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletAddCollisionMesh)
-    def add_collision_mesh(self, *args, **kwargs):
-        return PyBulletAddCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletAppendCollisionMesh)
-    def append_collision_mesh(self, *args, **kwargs):
-        return PyBulletAppendCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletRemoveCollisionMesh)
-    def remove_collision_mesh(self, *args, **kwargs):
-        return PyBulletRemoveCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletRemoveAttachedCollisionMesh)
-    def remove_attached_collision_mesh(self, *args, **kwargs):
-        return PyBulletRemoveAttachedCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletForwardKinematics)
-    def forward_kinematics(self, *args, **kwargs):
-        return PyBulletForwardKinematics(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletInverseKinematics)
-    def inverse_kinematics(self, *args, **kwargs):
-        return PyBulletInverseKinematics(self.client)(*args, **kwargs)
+        self.client = client

--- a/src/compas_fab/backends/ros/backend_features/__init__.py
+++ b/src/compas_fab/backends/ros/backend_features/__init__.py
@@ -1,3 +1,25 @@
+"""
+ROS backend features
+====================
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    MoveItAddAttachedCollisionMesh
+    MoveItAddCollisionMesh
+    MoveItAppendCollisionMesh
+    MoveItForwardKinematics
+    MoveItInverseKinematics
+    MoveItPlanCartesianMotion
+    MoveItPlanMotion
+    MoveItPlanningScene
+    MoveItRemoveAttachedCollisionMesh
+    MoveItRemoveCollisionMesh
+    MoveItResetPlanningScene
+
+"""
+
 from __future__ import absolute_import
 
 from compas_fab.backends.ros.backend_features.move_it_add_attached_collision_mesh import MoveItAddAttachedCollisionMesh

--- a/src/compas_fab/backends/ros/backend_features/move_it_add_attached_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_add_attached_collision_mesh.py
@@ -28,9 +28,6 @@ class MoveItAddAttachedCollisionMesh(AddAttachedCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def add_attached_collision_mesh(self, attached_collision_mesh, options=None):
         """Add a collision mesh and attach it to the robot.
 
@@ -56,5 +53,5 @@ class MoveItAddAttachedCollisionMesh(AddAttachedCollisionMesh):
         aco.object.operation = CollisionObject.ADD
         robot_state = RobotState(attached_collision_objects=[aco], is_diff=True)
         scene = PlanningScene(robot_state=robot_state, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_add_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_add_collision_mesh.py
@@ -27,9 +27,6 @@ class MoveItAddCollisionMesh(AddCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def add_collision_mesh(self, collision_mesh, options=None):
         """Add a collision mesh to the planning scene.
 
@@ -55,5 +52,5 @@ class MoveItAddCollisionMesh(AddCollisionMesh):
         co.operation = CollisionObject.ADD
         world = PlanningSceneWorld(collision_objects=[co])
         scene = PlanningScene(world=world, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_append_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_append_collision_mesh.py
@@ -27,9 +27,6 @@ class MoveItAppendCollisionMesh(AppendCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def append_collision_mesh(self, collision_mesh, options=None):
         """Append a collision mesh to the planning scene.
 
@@ -55,5 +52,5 @@ class MoveItAppendCollisionMesh(AppendCollisionMesh):
         co.operation = CollisionObject.APPEND
         world = PlanningSceneWorld(collision_objects=[co])
         scene = PlanningScene(world=world, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_forward_kinematics.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_forward_kinematics.py
@@ -26,9 +26,6 @@ class MoveItForwardKinematics(ForwardKinematics):
         "/compute_fk", "GetPositionFK", GetPositionFKRequest, GetPositionFKResponse, validate_response
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def forward_kinematics(self, robot, configuration, group=None, options=None):
         """Calculate the robot's forward kinematic.
 
@@ -83,9 +80,9 @@ class MoveItForwardKinematics(ForwardKinematics):
         header = Header(frame_id=base_link)
         joint_state = JointState(name=configuration.joint_names, position=configuration.joint_values, header=header)
         robot_state = RobotState(joint_state, MultiDOFJointState(header=header))
-        robot_state.filter_fields_for_distro(self.ros_client.ros_distro)
+        robot_state.filter_fields_for_distro(self.client.ros_distro)
 
         def convert_to_frame(response):
             callback(response.pose_stamped[0].pose.frame)
 
-        self.GET_POSITION_FK(self.ros_client, (header, fk_link_names, robot_state), convert_to_frame, errback)
+        self.GET_POSITION_FK(self.client, (header, fk_link_names, robot_state), convert_to_frame, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
@@ -32,9 +32,6 @@ class MoveItInverseKinematics(InverseKinematics):
         "/compute_ik", "GetPositionIK", GetPositionIKRequest, GetPositionIKResponse, validate_response
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
         """Calculate the robot's inverse kinematic for a given frame.
 
@@ -115,7 +112,7 @@ class MoveItInverseKinematics(InverseKinematics):
                 start_state.attached_collision_objects.append(aco)
 
         # Filter needs to happen after all objects have been added
-        start_state.filter_fields_for_distro(self.ros_client.ros_distro)
+        start_state.filter_fields_for_distro(self.client.ros_distro)
 
         constraints = convert_constraints_to_rosmsg(options.get("constraints"), header)
 
@@ -135,10 +132,10 @@ class MoveItInverseKinematics(InverseKinematics):
         # The field `attempts` was removed in Noetic (and higher)
         # so it needs to be removed from the message otherwise it causes a serialization error
         # https://github.com/ros-planning/moveit/pull/1288
-        if self.ros_client.ros_distro not in (RosDistro.KINETIC, RosDistro.MELODIC):
+        if self.client.ros_distro not in (RosDistro.KINETIC, RosDistro.MELODIC):
             del ik_request.attempts
 
         def convert_to_positions(response):
             callback((response.solution.joint_state.position, response.solution.joint_state.name))
 
-        self.GET_POSITION_IK(self.ros_client, (ik_request,), convert_to_positions, errback)
+        self.GET_POSITION_IK(self.client, (ik_request,), convert_to_positions, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_cartesian_motion.py
@@ -37,9 +37,6 @@ class MoveItPlanCartesianMotion(PlanCartesianMotion):
         validate_response,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def plan_cartesian_motion(self, robot, waypoints, start_configuration=None, group=None, options=None):
         """Calculates a cartesian motion path (linear in tool space).
 
@@ -137,7 +134,7 @@ class MoveItPlanCartesianMotion(PlanCartesianMotion):
                 start_state.attached_collision_objects.append(aco)
 
         # Filter needs to happen after all objects have been added
-        start_state.filter_fields_for_distro(self.ros_client.ros_distro)
+        start_state.filter_fields_for_distro(self.client.ros_distro)
 
         path_constraints = convert_constraints_to_rosmsg(options.get("path_constraints"), header)
 
@@ -162,7 +159,7 @@ class MoveItPlanCartesianMotion(PlanCartesianMotion):
             except Exception as e:
                 errback(e)
 
-        self.GET_CARTESIAN_PATH(self.ros_client, request, response_handler, errback)
+        self.GET_CARTESIAN_PATH(self.client, request, response_handler, errback)
 
     def plan_cartesian_motion_with_point_axis_waypoints_async(
         self, callback, errback, waypoints, start_configuration=None, group=None, options=None

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
@@ -29,9 +29,6 @@ class MoveItPlanMotion(PlanMotion):
         "/plan_kinematic_path", "GetMotionPlan", MotionPlanRequest, MotionPlanResponse, validate_response
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def plan_motion(self, robot, target, start_configuration=None, group=None, options=None):
         """Calculates a motion path.
 
@@ -93,6 +90,8 @@ class MoveItPlanMotion(PlanMotion):
         options["joints"] = {j.name: j.type for j in robot.model.joints}
         options["ee_link_name"] = robot.get_end_effector_link_name(group)
 
+        raise TypeError("This method is intentionally broken.")
+
         return await_callback(self.plan_motion_async, **kwargs)
 
     def plan_motion_async(self, callback, errback, target, start_configuration=None, group=None, options=None):
@@ -113,7 +112,7 @@ class MoveItPlanMotion(PlanMotion):
                 start_state.attached_collision_objects.append(aco)
 
         # Filter needs to happen after all objects have been added
-        start_state.filter_fields_for_distro(self.ros_client.ros_distro)
+        start_state.filter_fields_for_distro(self.client.ros_distro)
 
         # convert constraints
         ee_link_name = options["ee_link_name"]
@@ -150,4 +149,4 @@ class MoveItPlanMotion(PlanMotion):
             except Exception as e:
                 errback(e)
 
-        self.GET_MOTION_PLAN(self.ros_client, request, response_handler, errback)
+        self.GET_MOTION_PLAN(self.client, request, response_handler, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
@@ -90,8 +90,6 @@ class MoveItPlanMotion(PlanMotion):
         options["joints"] = {j.name: j.type for j in robot.model.joints}
         options["ee_link_name"] = robot.get_end_effector_link_name(group)
 
-        raise TypeError("This method is intentionally broken.")
-
         return await_callback(self.plan_motion_async, **kwargs)
 
     def plan_motion_async(self, callback, errback, target, start_configuration=None, group=None, options=None):

--- a/src/compas_fab/backends/ros/backend_features/move_it_planning_scene.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_planning_scene.py
@@ -22,9 +22,6 @@ class MoveItPlanningScene(GetPlanningScene):
         "/get_planning_scene", "GetPlanningScene", GetPlanningSceneRequest, GetPlanningSceneResponse
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def get_planning_scene(self, options=None):
         """Retrieve the planning scene.
 
@@ -54,4 +51,4 @@ class MoveItPlanningScene(GetPlanningScene):
                 | PlanningSceneComponents.OBJECT_COLORS
             )
         )
-        self.GET_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        self.GET_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_remove_attached_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_remove_attached_collision_mesh.py
@@ -28,9 +28,6 @@ class MoveItRemoveAttachedCollisionMesh(RemoveAttachedCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def remove_attached_collision_mesh(self, id, options=None):
         """Remove an attached collision mesh from the robot.
 
@@ -57,5 +54,5 @@ class MoveItRemoveAttachedCollisionMesh(RemoveAttachedCollisionMesh):
         aco.object.operation = CollisionObject.REMOVE
         robot_state = RobotState(attached_collision_objects=[aco], is_diff=True)
         scene = PlanningScene(robot_state=robot_state, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_remove_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_remove_collision_mesh.py
@@ -27,9 +27,6 @@ class MoveItRemoveCollisionMesh(RemoveCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def remove_collision_mesh(self, id, options=None):
         """Remove a collision mesh from the planning scene.
 
@@ -56,5 +53,5 @@ class MoveItRemoveCollisionMesh(RemoveCollisionMesh):
         co.operation = CollisionObject.REMOVE
         world = PlanningSceneWorld(collision_objects=[co])
         scene = PlanningScene(world=world, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_reset_planning_scene.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_reset_planning_scene.py
@@ -25,9 +25,6 @@ class MoveItResetPlanningScene(ResetPlanningScene):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def reset_planning_scene(self, options=None):
         """Resets the planning scene, removing all added collision meshes.
 
@@ -46,12 +43,12 @@ class MoveItResetPlanningScene(ResetPlanningScene):
         return await_callback(self.reset_planning_scene_async, **kwargs)
 
     def reset_planning_scene_async(self, callback, errback):
-        scene = self.ros_client.get_planning_scene()
+        scene = self.client.get_planning_scene()
         for collision_object in scene.world.collision_objects:
             collision_object.operation = CollisionObject.REMOVE
         for collision_object in scene.robot_state.attached_collision_objects:
             collision_object.object["operation"] = CollisionObject.REMOVE
         scene.is_diff = True
         scene.robot_state.is_diff = True
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/planner.py
+++ b/src/compas_fab/backends/ros/planner.py
@@ -7,7 +7,8 @@ from __future__ import division
 from __future__ import print_function
 
 from compas_fab.backends.interfaces.client import PlannerInterface
-from compas_fab.backends.interfaces.client import forward_docstring
+
+# from compas_fab.backends.interfaces.client import forward_docstring
 from compas_fab.backends.ros.backend_features import MoveItResetPlanningScene
 from compas_fab.backends.ros.backend_features.move_it_add_attached_collision_mesh import MoveItAddAttachedCollisionMesh
 from compas_fab.backends.ros.backend_features.move_it_add_collision_mesh import MoveItAddCollisionMesh
@@ -27,52 +28,21 @@ __all__ = [
 ]
 
 
-class MoveItPlanner(PlannerInterface):
+class MoveItPlanner(
+    MoveItForwardKinematics,
+    MoveItInverseKinematics,
+    MoveItPlanMotion,
+    MoveItPlanCartesianMotion,
+    MoveItPlanningScene,
+    MoveItResetPlanningScene,
+    MoveItAddCollisionMesh,
+    MoveItRemoveCollisionMesh,
+    MoveItAppendCollisionMesh,
+    MoveItAddAttachedCollisionMesh,
+    MoveItRemoveAttachedCollisionMesh,
+    PlannerInterface,
+):
     """Implement the planner backend interface based on MoveIt!"""
 
     def __init__(self, client):
-        super(MoveItPlanner, self).__init__(client)
-
-    @forward_docstring(MoveItForwardKinematics)
-    def forward_kinematics(self, *args, **kwargs):
-        return MoveItForwardKinematics(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItInverseKinematics)
-    def inverse_kinematics(self, *args, **kwargs):
-        return MoveItInverseKinematics(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItPlanCartesianMotion)
-    def plan_cartesian_motion(self, *args, **kwargs):
-        return MoveItPlanCartesianMotion(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItPlanMotion)
-    def plan_motion(self, *args, **kwargs):
-        return MoveItPlanMotion(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItPlanningScene)
-    def get_planning_scene(self, *args, **kwargs):
-        return MoveItPlanningScene(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItResetPlanningScene)
-    def reset_planning_scene(self, *args, **kwargs):
-        return MoveItResetPlanningScene(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItAddCollisionMesh)
-    def add_collision_mesh(self, *args, **kwargs):
-        return MoveItAddCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItRemoveCollisionMesh)
-    def remove_collision_mesh(self, *args, **kwargs):
-        return MoveItRemoveCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItAppendCollisionMesh)
-    def append_collision_mesh(self, *args, **kwargs):
-        return MoveItAppendCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItAddAttachedCollisionMesh)
-    def add_attached_collision_mesh(self, *args, **kwargs):
-        return MoveItAddAttachedCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItRemoveAttachedCollisionMesh)
-    def remove_attached_collision_mesh(self, *args, **kwargs):
-        return MoveItRemoveAttachedCollisionMesh(self.client)(*args, **kwargs)
+        self.client = client

--- a/src/compas_fab/backends/ros/planner.py
+++ b/src/compas_fab/backends/ros/planner.py
@@ -1,5 +1,6 @@
 """
 Internal implementation of the planner backend interface for MoveIt!
+
 """
 
 from __future__ import absolute_import

--- a/tests/robots/test_robot.py
+++ b/tests/robots/test_robot.py
@@ -83,7 +83,7 @@ def ur5_with_fake_ik(ur5_robot_instance, fake_client):
                 yield (ik[0], ik[2])
 
     ur5_robot_instance.client = fake_client
-    ur5_robot_instance.client.inverse_kinematics = FakeInverseKinematics()
+    ur5_robot_instance.client.inverse_kinematics = FakeInverseKinematics(fake_client).inverse_kinematics
 
     return ur5_robot_instance
 


### PR DESCRIPTION
This PR changes the way `BackendFeature` are structured. 
The previous method of implementing a class with a function and use `__call__` to make that class callable is no longer used.

Instead the classes are now treated as a mix-in class for the Planner to mix-in using multiple inheritance. A new `BackendFeature` class is added and serves as the base class for all the backend feature classes. It contains an interface to the `Client` which allows their code to make calls to the client.

There is no practical change to the way how users interact with the API. 

The main benefit is that the generated documentation has a functional link to the code that implemented that function.
The second benefit is that the 

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
