### PR TITLE
Pin compas version in ironpython workflow

### DIFF
--- a/.github/workflows/ironpython.yml
+++ b/.github/workflows/ironpython.yml
@@ -16,15 +16,34 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
+          echo "Installing IronPython..."
           choco install ironpython --version=2.7.8.1
+
+          echo "Downloading ironpython-pytest..."
           curl -o ironpython-pytest.tar.gz -LJO https://pypi.debian.net/ironpython-pytest/latest
-          curl -o compas.tar.gz -LJO https://pypi.debian.net/COMPAS/latest
+
+          echo "Downloading COMPAS..."
+          curl -o compas.tar.gz -LJO https://pypi.debian.net/COMPAS/COMPAS-2.1.0.tar.gz
+
+          echo "Downloading roslibpy..."
           curl -o roslibpy.tar.gz -LJO https://pypi.debian.net/roslibpy/latest
+
+          echo "Downloading compas_robots..."
           curl -o compas_robots.tar.gz -LJO https://pypi.debian.net/compas_robots/latest
+
+          echo "Setting up IronPython environment..."
           ipy -X:Frames -m ensurepip
+
+          echo "Installing ironpython-pytest..."
           ipy -X:Frames -m pip install --no-deps ironpython-pytest.tar.gz
+
+          echo "Installing COMPAS..."
           ipy -X:Frames -m pip install --no-deps compas.tar.gz
+          
+          echo "Installing roslibpy..."
           ipy -X:Frames -m pip install --no-deps roslibpy.tar.gz
+
+          echo "Installing compas_robots..."
           ipy -X:Frames -m pip install --no-deps compas_robots.tar.gz
       - uses: NuGet/setup-nuget@v1.0.5
       - uses: compas-dev/compas-actions.ghpython_components@v5
@@ -33,11 +52,13 @@ jobs:
           target: src/compas_fab/ghpython/components/ghuser
       - name: Test import
         run: |
+          echo "Testing import of compas_fab..."
           ipy -m compas_fab
         env:
           IRONPYTHONPATH: ./src
       - name: Run tests
         run: |
+          echo "Running tests..."
           ipy tests/ipy_test_runner.py
         env:
           IRONPYTHONPATH: ./src


### PR DESCRIPTION
This is to temporarily avoid problem with the IPY workflow.

See this failed action for example:
https://github.com/compas-dev/compas_fab/actions/runs/9294697625/job/25580341228#step:3:837