### PR TITLE
Tests for PyBulletClient and PyBulletPlanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added unit test for `PyBulletClient` and `PyBulletPlanner` backend features, including Ik and FK agreement tests.
 * Added `PyBulletClient.load_existing_robot` to load from an existing Robot, such as those in RobotLibrary.
 * Added `compas_fab.robots.Waypoints` class to represent a sequence of targets. It has two child classes: `FrameWaypoints` and `PointAxisWaypoints`.
 * Added `compas_fab.robots.Target` class to represent a motion planning target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `PyBulletClient.load_existing_robot` to load from an existing Robot, such as those in RobotLibrary.
 * Added `compas_fab.robots.Waypoints` class to represent a sequence of targets. It has two child classes: `FrameWaypoints` and `PointAxisWaypoints`.
 * Added `compas_fab.robots.Target` class to represent a motion planning target.
 * Added also child classes `FrameTarget`, `PointAxisTarget`, `ConfigurationTarget`, `ConstraintSetTarget`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `Robot.plan_carteisan_motion()` now accepts `Waypoints` as target. Implementation for `FrameWaypoints` is supported with same functionality as before. Simply wrap `Frame` objects using `FrameWaypoints(frames)`.
+* `Robot.plan_cartesian_motion()` now accepts `Waypoints` as target. Implementation for `FrameWaypoints` is supported with same functionality as before. Simply wrap `Frame` objects using `FrameWaypoints(frames)`.
 * Changed `BoundingVolume`, `Constraint`, `JointConstraint`, `OrientationConstraint`, `PositionConstraint` to inherit from `compas.data.Data` class.
 * Change the signature of `plan_motion()` to use `target` (`Target` class) instead of `goal_constraints`. Only one target is accepted. Users who wish to compose their own constraint sets can still use `ConstraintSetTarget`.
 * Moved `Robot.orientation_constraint_from_frame()` to `OrientationConstraint.from_frame()`, as constraints are no longer intended for users to use directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Backend planners now use multi-inherence instead of `__call__` to include the backend functions. This allows for better generated documentation.
 * `Robot.plan_carteisan_motion()` now accepts `Waypoints` as target. Implementation for `FrameWaypoints` is supported with same functionality as before. Simply wrap `Frame` objects using `FrameWaypoints(frames)`.
 * Changed `BoundingVolume`, `Constraint`, `JointConstraint`, `OrientationConstraint`, `PositionConstraint` to inherit from `compas.data.Data` class.
 * Change the signature of `plan_motion()` to use `target` (`Target` class) instead of `goal_constraints`. Only one target is accepted. Users who wish to compose their own constraint sets can still use `ConstraintSetTarget`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* `Robot.plan_carteisan_motion()` now accepts `Waypoints` as target. Implementation for `FrameWaypoints` is supported with same functionality as before. Simply wrap `Frame` objects using `FrameWaypoints(frames)`.
 * Changed `BoundingVolume`, `Constraint`, `JointConstraint`, `OrientationConstraint`, `PositionConstraint` to inherit from `compas.data.Data` class.
 * Change the signature of `plan_motion()` to use `target` (`Target` class) instead of `goal_constraints`. Only one target is accepted. Users who wish to compose their own constraint sets can still use `ConstraintSetTarget`.
 * Moved `Robot.orientation_constraint_from_frame()` to `OrientationConstraint.from_frame()`, as constraints are no longer intended for users to use directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed error in `PyBulletForwardKinematics.forward_kinematics` where function would crash if `options` was not passed.
 * Fixed error in `PyBulletInverseKinematics._accurate_inverse_kinematics` where threshold was not squared for comparison.
 * Renamed `PybulletClient.get_cached_robot` to `PybulletClient.get_cached_robot_model` to avoid confusion between the `RobotModel` and `Robot` class.
 * Renamed `PybulletClient.ensure_cached_robot` to `PybulletClient.ensure_cached_robot_model`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed error in `PyBulletInverseKinematics._accurate_inverse_kinematics` where threshold was not squared for comparison.
 * Renamed `PybulletClient.get_cached_robot` to `PybulletClient.get_cached_robot_model` to avoid confusion between the `RobotModel` and `Robot` class.
 * Renamed `PybulletClient.ensure_cached_robot` to `PybulletClient.ensure_cached_robot_model`.
 * Renamed `PybulletClient.ensure_cached_robot_geometry` to `PybulletClient.ensure_cached_robot_model_geometry`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Renamed `PybulletClient.get_cached_robot` to `PybulletClient.get_cached_robot_model` to avoid confusion between the `RobotModel` and `Robot` class.
+* Renamed `PybulletClient.ensure_cached_robot` to `PybulletClient.ensure_cached_robot_model`.
+* Renamed `PybulletClient.ensure_cached_robot_geometry` to `PybulletClient.ensure_cached_robot_model_geometry`.
+* Renamed `PybulletClient.cache_robot` to `PybulletClient.cache_robot_model`.
 * Backend planners now use multi-inherence instead of `__call__` to include the backend functions. This allows for better generated documentation.
 * `Robot.plan_carteisan_motion()` now accepts `Waypoints` as target. Implementation for `FrameWaypoints` is supported with same functionality as before. Simply wrap `Frame` objects using `FrameWaypoints(frames)`.
 * Changed `BoundingVolume`, `Constraint`, `JointConstraint`, `OrientationConstraint`, `PositionConstraint` to inherit from `compas.data.Data` class.

--- a/docs/developer/backends.rst
+++ b/docs/developer/backends.rst
@@ -82,3 +82,15 @@ Backend interfaces
 ==================
 
 .. automodule:: compas_fab.backends.interfaces
+
+Implemented backend features
+============================
+
+The following backend features are implemented for the ROS backend:
+
+.. automodule:: compas_fab.backends.ros.backend_features
+
+The following backend features are implemented for the PyBullet backend:
+
+.. automodule:: compas_fab.backends.pybullet.backend_features
+

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -38,3 +38,10 @@ The :class:`compas_fab.robots.ConstraintSetTarget` class is used to specify a li
 constraints as a planning target. This is intended for advanced users who want to create custom
 combination of constraints. See :class:`compas_fab.robots.Constraint` for available
 constraints. At the moment, only the ROS MoveIt planning backend supports this target type.
+
+------------------------------------------
+Waypoints Target (Multiple Point Segments)
+------------------------------------------
+
+The :class:`compas_fab.robots.Waypoint` classes are used to describe a sequence of
+waypoints that the robot should pass through.

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -38,6 +38,8 @@ constraints as a planning target. This is intended for advanced users who want t
 combination of constraints. See :class:`compas_fab.robots.Constraint` for available
 constraints. At the moment, only the ROS MoveIt planning backend supports this target type.
 
+.. _waypoints:
+
 ------------------------------------------
 Waypoints (Multiple Points / Segments)
 ------------------------------------------

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -1,16 +1,15 @@
 .. _targets:
 
 *******************************************************************************
-Targets
+Targets and Waypoints
 *******************************************************************************
 
 -----------------------
-Single Targets (Static)
+Targets (Single Goal)
 -----------------------
 
 Target classes are used to describe the goal condition (i.e. end condition) of a robot
-for motion planning. They can be used for both Free Motion Planning (FMP) and Cartesian
-Motion Planning (CMP).
+for motion planning. They can be used for Free Motion Planning with :meth:`compas_fab.robots.Robot.plan_motion`.
 
 The :class:`compas_fab.robots.FrameTarget` is the most common target for motion planning.
 It defines the complete pose of the end-effector (or the robot flange, if no tool is attached).
@@ -40,8 +39,25 @@ combination of constraints. See :class:`compas_fab.robots.Constraint` for availa
 constraints. At the moment, only the ROS MoveIt planning backend supports this target type.
 
 ------------------------------------------
-Waypoints Target (Multiple Point Segments)
+Waypoints (Multiple Points / Segments)
 ------------------------------------------
 
-The :class:`compas_fab.robots.Waypoint` classes are used to describe a sequence of
-waypoints that the robot should pass through.
+The :class:`compas_fab.robots.Waypoints` classes are used to describe a sequence of
+waypoints that the robot should pass through in a planned motion. They are similar to Targets classes
+but contain a list of targets instead of a single target, which is useful for tasks such as
+drawing, welding or 3D printing.
+They can be used for Cartesian Motion Planning with :meth:`compas_fab.robots.Robot.plan_cartesian_motion`.
+
+The :class:`compas_fab.robots.FrameWaypoints` is the most common waypoint for Cartesian motion planning.
+It defines a list of complete pose for the end-effector (or the robot flange, if no tool is attached).
+It is created by a list of :class:`compas.geometry.Frame` objects or alternatively from a list of
+:class:`compas.geometry.Transformation` objects.
+
+The :class:`compas_fab.robots.PointAxisWaypoints` class is used for specifying a list of waypoints based on
+the Point-Axis concept used in the :class:`compas_fab.robots.PointAxisTarget`. Compared to
+:class:`~compas_fab.robots.FrameWaypoints`, this class allows for specifying a targets where the rotation
+around the Z-axis is not fixed. This is useful for example when the robot is using a cylindrical tool
+to perform a task, for example 3D printing, welding or drilling. The freely rotating axis is defined relative
+to the Z-axis of the tool coordinate frame (TCF). Note that the orientation of the tool
+at the end of the motion is not determined until after the motion is planned.
+

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -9,7 +9,7 @@ Targets (Single Goal)
 -----------------------
 
 Target classes are used to describe the goal condition (i.e. end condition) of a robot
-for motion planning. They can be used for Free Motion Planning with :meth:`compas_fab.robots.Robot.plan_motion`.
+for motion planning. They can be used for Free-space Motion Planning with :meth:`compas_fab.robots.Robot.plan_motion`.
 
 The :class:`compas_fab.robots.FrameTarget` is the most common target for motion planning.
 It defines the complete pose of the end-effector (or the robot flange, if no tool is attached).
@@ -42,7 +42,7 @@ constraints. At the moment, only the ROS MoveIt planning backend supports this t
 Waypoints (Multiple Points / Segments)
 ------------------------------------------
 
-The :class:`compas_fab.robots.Waypoints` classes are used to describe a sequence of
+Waypoints classes are used to describe a sequence of
 waypoints that the robot should pass through in a planned motion. They are similar to Targets classes
 but contain a list of targets instead of a single target, which is useful for tasks such as
 drawing, welding or 3D printing.

--- a/docs/examples/02_description_models/03_targets.rst
+++ b/docs/examples/02_description_models/03_targets.rst
@@ -55,7 +55,7 @@ It is created by a list of :class:`compas.geometry.Frame` objects or alternative
 
 The :class:`compas_fab.robots.PointAxisWaypoints` class is used for specifying a list of waypoints based on
 the Point-Axis concept used in the :class:`compas_fab.robots.PointAxisTarget`. Compared to
-:class:`~compas_fab.robots.FrameWaypoints`, this class allows for specifying a targets where the rotation
+:class:`~compas_fab.robots.FrameWaypoints`, this class allows for specifying targets where the rotation
 around the Z-axis is not fixed. This is useful for example when the robot is using a cylindrical tool
 to perform a task, for example 3D printing, welding or drilling. The freely rotating axis is defined relative
 to the Z-axis of the tool coordinate frame (TCF). Note that the orientation of the tool

--- a/docs/examples/03_backends_ros/files/04_plan_cartesian_motion.py
+++ b/docs/examples/03_backends_ros/files/04_plan_cartesian_motion.py
@@ -1,25 +1,25 @@
 from compas.geometry import Frame
 
 from compas_fab.backends import RosClient
+from compas_fab.robots import FrameWaypoints
 
 with RosClient() as client:
     robot = client.load_robot()
-    assert robot.name == 'ur5_robot'
+    assert robot.name == "ur5_robot"
 
     frames = []
     frames.append(Frame([0.3, 0.1, 0.5], [1, 0, 0], [0, 1, 0]))
     frames.append(Frame([0.5, 0.1, 0.6], [1, 0, 0], [0, 1, 0]))
+    waypoints = FrameWaypoints(frames)
 
     start_configuration = robot.zero_configuration()
     start_configuration.joint_values = (-0.042, 0.033, -2.174, 5.282, -1.528, 0.000)
     options = {
-        'max_step': 0.01,
-        'avoid_collisions': True,
+        "max_step": 0.01,
+        "avoid_collisions": True,
     }
 
-    trajectory = robot.plan_cartesian_motion(frames,
-                                             start_configuration,
-                                             options=options)
+    trajectory = robot.plan_cartesian_motion(waypoints, start_configuration, options=options)
 
     print("Computed cartesian path with %d configurations, " % len(trajectory.points))
     print("following %d%% of requested trajectory." % (trajectory.fraction * 100))

--- a/docs/examples/03_backends_ros/files/gh_plan_cartesian_motion.py
+++ b/docs/examples/03_backends_ros/files/gh_plan_cartesian_motion.py
@@ -22,11 +22,12 @@
         :class:`compas_fab.robots.JointTrajectory`
             The calculated trajectory.
 """
+
 from __future__ import print_function
 import scriptcontext as sc
 
 from compas.geometry import Frame
-
+from compas_fab.robots import FrameWaypoints
 
 guid = str(ghenv.Component.InstanceGuid)
 response_key = "response_" + guid
@@ -38,14 +39,14 @@ frames = [Frame(plane.Origin, plane.XAxis, plane.YAxis) for plane in planes]
 if robot and robot.client and start_configuration and compute:
     if robot.client.is_connected:
         options = {
-            'max_step': float(max_step),
-            'avoid_collisions': bool(avoid_collisions),
-            'attached_collision_meshes': list(attached_colllision_meshes),
+            "max_step": float(max_step),
+            "avoid_collisions": bool(avoid_collisions),
+            "attached_collision_meshes": list(attached_colllision_meshes),
         }
-        sc.sticky[response_key] = robot.plan_cartesian_motion(frames,
-                                                              start_configuration=start_configuration,
-                                                              group=group,
-                                                              options=options)
+        waypoints = FrameWaypoints(frames)
+        sc.sticky[response_key] = robot.plan_cartesian_motion(
+            waypoints, start_configuration=start_configuration, group=group, options=options
+        )
     else:
         print("Robot client is not connected")
 

--- a/docs/examples/06_backends_kinematics/files/04_cartesian_path_analytic_pybullet.py
+++ b/docs/examples/06_backends_kinematics/files/04_cartesian_path_analytic_pybullet.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 from compas.geometry import Frame
 
 from compas_fab.backends import AnalyticalPyBulletClient
+from compas_fab.robots import FrameWaypoints
 
 frames_WCF = [
     Frame((0.407, 0.073, 0.320), (0.922, 0.000, 0.388), (0.113, 0.956, -0.269)),
@@ -16,7 +17,8 @@ with AnalyticalPyBulletClient(connection_type="direct") as client:
 
     options = {"solver": "ur5", "check_collision": True}
     start_configuration = list(robot.iter_inverse_kinematics(frames_WCF[0], options=options))[-1]
-    trajectory = robot.plan_cartesian_motion(frames_WCF, start_configuration=start_configuration, options=options)
+    waypoints = FrameWaypoints(frames_WCF)
+    trajectory = robot.plan_cartesian_motion(waypoints, start_configuration=start_configuration, options=options)
     assert trajectory.fraction == 1.0
 
     j = [c.joint_values for c in trajectory.points]

--- a/src/compas_fab/backends/__init__.py
+++ b/src/compas_fab/backends/__init__.py
@@ -147,13 +147,16 @@ from .kinematics import (
     Staubli_TX260LKinematics,
     ABB_IRB4600_40_255Kinematics,
 )
-from .pybullet import (
-    PyBulletClient,
-    CollisionError,
-    PyBulletError,
-    PyBulletPlanner,
-    AnalyticalPyBulletClient,
-)
+
+if not compas.IPY:
+    # PyBullet do not work in IronPython
+    from .pybullet import (
+        PyBulletClient,
+        CollisionError,
+        PyBulletError,
+        PyBulletPlanner,
+        AnalyticalPyBulletClient,
+    )
 
 __all__ = [
     # Base

--- a/src/compas_fab/backends/__init__.py
+++ b/src/compas_fab/backends/__init__.py
@@ -147,15 +147,13 @@ from .kinematics import (
     Staubli_TX260LKinematics,
     ABB_IRB4600_40_255Kinematics,
 )
-
-if not compas.IPY:
-    from .pybullet import (
-        PyBulletClient,
-        CollisionError,
-        PyBulletError,
-        PyBulletPlanner,
-        AnalyticalPyBulletClient,
-    )
+from .pybullet import (
+    PyBulletClient,
+    CollisionError,
+    PyBulletError,
+    PyBulletPlanner,
+    AnalyticalPyBulletClient,
+)
 
 __all__ = [
     # Base

--- a/src/compas_fab/backends/interfaces/__init__.py
+++ b/src/compas_fab/backends/interfaces/__init__.py
@@ -21,6 +21,7 @@ Feature interfaces
     :toctree: generated/
     :nosignatures:
 
+    BackendFeature
     ForwardKinematics
     InverseKinematics
     PlanMotion

--- a/src/compas_fab/backends/interfaces/__init__.py
+++ b/src/compas_fab/backends/interfaces/__init__.py
@@ -46,6 +46,7 @@ Planning scene interfaces
 from .backend_features import AddAttachedCollisionMesh
 from .backend_features import AddCollisionMesh
 from .backend_features import AppendCollisionMesh
+from .backend_features import BackendFeature
 from .backend_features import ForwardKinematics
 from .backend_features import GetPlanningScene
 from .backend_features import InverseKinematics
@@ -58,17 +59,18 @@ from .client import ClientInterface
 from .client import PlannerInterface
 
 __all__ = [
-    "ForwardKinematics",
-    "InverseKinematics",
-    "PlanMotion",
-    "PlanCartesianMotion",
-    "GetPlanningScene",
+    "AddAttachedCollisionMesh",
     "AddCollisionMesh",
     "AppendCollisionMesh",
+    "BackendFeature",
+    "ClientInterface",
+    "ForwardKinematics",
+    "GetPlanningScene",
+    "InverseKinematics",
+    "PlanCartesianMotion",
+    "PlanMotion",
+    "PlannerInterface",
     "RemoveCollisionMesh",
-    "AddAttachedCollisionMesh",
     "RemoveAttachedCollisionMesh",
     "ResetPlanningScene",
-    "ClientInterface",
-    "PlannerInterface",
 ]

--- a/src/compas_fab/backends/interfaces/backend_features.py
+++ b/src/compas_fab/backends/interfaces/backend_features.py
@@ -2,18 +2,32 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import compas
 
-class ForwardKinematics(object):
-    """Interface for a Planner's forward kinematics feature.  Any implementation of
-    ``ForwardKinematics`` must define the method ``forward_kinematics``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``ForwardKinematics`` to be treated as its ``forward_kinematics`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
+if not compas.IPY:
+    from typing import TYPE_CHECKING
 
-    def __call__(self, robot, configuration, group=None, options=None):
-        return self.forward_kinematics(robot, configuration, group, options)
+    if TYPE_CHECKING:
+        from compas_fab.backends.interfaces import ClientInterface  # noqa: F401
+
+
+class BackendFeature(object):
+    """Base class for all backend features that are implemented by a backend client."""
+
+    def __init__(self, client):
+        # All backend features are assumed to be associated with a backend client.
+        self.client = client  # type: ClientInterface
+
+
+#   The code that contains the actual feature implementation is located in the backend's module.
+#   For example, the features for moveit planner and ros client are located in :
+#   "src/compas_fab/backends/ros/backend_features/"
+#   If you cannot a specific feature in the 'backend_features', it means that the planner
+#   does not support that feature.
+
+
+class ForwardKinematics(BackendFeature):
+    """Mix-in interface for implementing a planner's forward kinematics feature."""
 
     def forward_kinematics(self, robot, configuration, group=None, options=None):
         """Calculate the robot's forward kinematic.
@@ -40,17 +54,8 @@ class ForwardKinematics(object):
         pass
 
 
-class InverseKinematics(object):
-    """Interface for a Planner's inverse kinematics feature.  Any implementation of
-    ``InverseKinematics`` must define the method ``inverse_kinematics``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``InverseKinematics`` to be treated as its ``inverse_kinematics`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
-        return self.inverse_kinematics(robot, frame_WCF, start_configuration, group, options)
+class InverseKinematics(BackendFeature):
+    """Mix-in interface for implementing a planner's inverse kinematics feature."""
 
     def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
         """Calculate the robot's inverse kinematic for a given frame.
@@ -78,17 +83,8 @@ class InverseKinematics(object):
         pass
 
 
-class PlanMotion(object):
-    """Interface for a Planner's plan motion feature.  Any implementation of
-    ``PlanMotion`` must define the method ``plan_motion``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``PlanMotion`` to be treated as its ``plan_motion`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, robot, target, start_configuration=None, group=None, options=None):
-        return self.plan_motion(robot, target, start_configuration, group, options)
+class PlanMotion(BackendFeature):
+    """Mix-in interface for implementing a planner's plan motion feature."""
 
     def plan_motion(self, robot, target, start_configuration=None, group=None, options=None):
         """Calculates a motion path.
@@ -116,17 +112,8 @@ class PlanMotion(object):
         pass
 
 
-class PlanCartesianMotion(object):
-    """Interface for a Planner's plan cartesian motion feature.  Any implementation of
-    ``PlanCartesianMotion`` must define the method ``plan_cartesian_motion``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``PlanCartesianMotion`` to be treated as its ``plan_cartesian_motion`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, robot, waypoints, start_configuration=None, group=None, options=None):
-        return self.plan_cartesian_motion(robot, waypoints, start_configuration, group, options)
+class PlanCartesianMotion(BackendFeature):
+    """Mix-in interface for implementing a planner's plan cartesian motion feature."""
 
     def plan_cartesian_motion(self, robot, waypoints, start_configuration=None, group=None, options=None):
         """Calculates a cartesian motion path (linear in tool space).
@@ -154,17 +141,8 @@ class PlanCartesianMotion(object):
         pass
 
 
-class GetPlanningScene(object):
-    """Interface for a Planner's get planning scene feature.  Any implementation of
-    ``GetPlanningScene`` must define the method ``get_planning_scene``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``GetPlanningScene`` to be treated as its ``get_planning_scene`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, options=None):
-        return self.get_planning_scene(options)
+class GetPlanningScene(BackendFeature):
+    """Mix-in interface for implementing a planner's get planning scene feature."""
 
     def get_planning_scene(self, options=None):
         """Retrieve the planning scene.
@@ -182,20 +160,11 @@ class GetPlanningScene(object):
         pass
 
 
-class ResetPlanningScene(object):
-    """Interface for a Planner's reset planning scene feature.  Any implementation of
-    ``ResetPlanningScene`` must define the method ``reset_planning_scene``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``ResetPlanningScene`` to be treated as its ``reset_planning_scene`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, options=None):
-        return self.reset_planning_scene(options)
+class ResetPlanningScene(BackendFeature):
+    """Mix-in interface for implementing a planner's reset planning scene feature."""
 
     def reset_planning_scene(self, options=None):
-        """Retrieve the planning scene.
+        """Resets the planning scene, removing all added collision meshes.
 
         Parameters
         ----------
@@ -210,17 +179,8 @@ class ResetPlanningScene(object):
         pass
 
 
-class AddCollisionMesh(object):
-    """Interface for a Planner's add collision mesh feature.  Any implementation of
-    ``AddCollisionMesh`` must define the method ``add_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``AddCollisionMesh`` to be treated as its ``add_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, collision_mesh, options=None):
-        return self.add_collision_mesh(collision_mesh, options)
+class AddCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's add collision mesh feature."""
 
     def add_collision_mesh(self, collision_mesh, options=None):
         """Add a collision mesh to the planning scene.
@@ -240,17 +200,8 @@ class AddCollisionMesh(object):
         pass
 
 
-class RemoveCollisionMesh(object):
-    """Interface for a Planner's remove collision mesh feature.  Any implementation of
-    ``RemoveCollisionMesh`` must define the method ``remove_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``RemoveCollisionMesh`` to be treated as its ``remove_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, id, options=None):
-        return self.remove_collision_mesh(id, options)
+class RemoveCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's remove collision mesh feature."""
 
     def remove_collision_mesh(self, id, options=None):
         """Remove a collision mesh from the planning scene.
@@ -270,17 +221,8 @@ class RemoveCollisionMesh(object):
         pass
 
 
-class AppendCollisionMesh(object):
-    """Interface for a Planner's append collision mesh feature.  Any implementation of
-    ``AppendCollisionMesh`` must define the method ``append_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``AppendCollisionMesh`` to be treated as its ``append_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, collision_mesh, options=None):
-        return self.append_collision_mesh(collision_mesh, options)
+class AppendCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's append collision mesh feature."""
 
     def append_collision_mesh(self, collision_mesh, options=None):
         """Append a collision mesh to the planning scene.
@@ -300,17 +242,8 @@ class AppendCollisionMesh(object):
         pass
 
 
-class AddAttachedCollisionMesh(object):
-    """Interface for a Planner's add attached collision mesh feature.  Any implementation of
-    ``AddAttachedCollisionMesh`` must define the method ``add_attached_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``AddAttachedCollisionMesh`` to be treated as its ``add_attached_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, attached_collision_mesh, options=None):
-        return self.add_attached_collision_mesh(attached_collision_mesh, options)
+class AddAttachedCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's add attached collision mesh feature."""
 
     def add_attached_collision_mesh(self, attached_collision_mesh, options=None):
         """Add a collision mesh and attach it to the robot.
@@ -330,17 +263,8 @@ class AddAttachedCollisionMesh(object):
         pass
 
 
-class RemoveAttachedCollisionMesh(object):
-    """Interface for a Planner's remove attached collision mesh feature.  Any implementation of
-    ``RemoveAttachedCollisionMesh`` must define the method ``remove_attached_collision_mesh``.  The
-    ``__call__`` magic method allows an instance of an implementation of
-    ``RemoveAttachedCollisionMesh`` to be treated as its ``remove_attached_collision_mesh`` method.  See
-    <https://docs.python.org/3/reference/datamodel.html#object.__call__> and
-    <https://en.wikipedia.org/wiki/Function_object#In_Python>.
-    """
-
-    def __call__(self, id, options=None):
-        return self.remove_attached_collision_mesh(id, options)
+class RemoveAttachedCollisionMesh(BackendFeature):
+    """Mix-in interface for implementing a planner's remove attached collision mesh feature."""
 
     def remove_attached_collision_mesh(self, id, options=None):
         """Remove an attached collision mesh from the robot.

--- a/src/compas_fab/backends/interfaces/backend_features.py
+++ b/src/compas_fab/backends/interfaces/backend_features.py
@@ -125,18 +125,18 @@ class PlanCartesianMotion(object):
     <https://en.wikipedia.org/wiki/Function_object#In_Python>.
     """
 
-    def __call__(self, robot, frames_WCF, start_configuration=None, group=None, options=None):
-        return self.plan_cartesian_motion(robot, frames_WCF, start_configuration, group, options)
+    def __call__(self, robot, waypoints, start_configuration=None, group=None, options=None):
+        return self.plan_cartesian_motion(robot, waypoints, start_configuration, group, options)
 
-    def plan_cartesian_motion(self, robot, frames_WCF, start_configuration=None, group=None, options=None):
+    def plan_cartesian_motion(self, robot, waypoints, start_configuration=None, group=None, options=None):
         """Calculates a cartesian motion path (linear in tool space).
 
         Parameters
         ----------
         robot : :class:`compas_fab.robots.Robot`
             The robot instance for which the cartesian motion path is being calculated.
-        frames_WCF: list of :class:`compas.geometry.Frame`
-            The frames through which the path is defined.
+        waypoints : :class:`compas_fab.robots.Waypoints`
+            The waypoints for the robot to follow.
         start_configuration: :class:`compas_robots.Configuration`, optional
             The robot's full configuration, i.e. values for all configurable
             joints of the entire robot, at the starting position.

--- a/src/compas_fab/backends/interfaces/backend_features.py
+++ b/src/compas_fab/backends/interfaces/backend_features.py
@@ -12,7 +12,14 @@ if not compas.IPY:
 
 
 class BackendFeature(object):
-    """Base class for all backend features that are implemented by a backend client."""
+    """Base class for all backend features that are implemented by a backend client.
+
+    Attributes
+    ----------
+    client : :class:`compas_fab.backends.interfaces.ClientInterface`
+        The backend client that supports this feature.
+
+    """
 
     def __init__(self, client):
         # All backend features are assumed to be associated with a backend client.
@@ -36,7 +43,7 @@ class ForwardKinematics(BackendFeature):
         ----------
         robot : :class:`compas_fab.robots.Robot`
             The robot instance for which forward kinematics is being calculated.
-        configuration : :class:`compas_fab.robots.Configuration`
+        configuration : :class:`compas_robots.Configuration`
             The full configuration to calculate the forward kinematic for. If no
             full configuration is passed, the zero-joint state for the other
             configurable joints is assumed.
@@ -53,6 +60,9 @@ class ForwardKinematics(BackendFeature):
         """
         pass
 
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_forward_kinematics.py"
+
 
 class InverseKinematics(BackendFeature):
     """Mix-in interface for implementing a planner's inverse kinematics feature."""
@@ -66,12 +76,12 @@ class InverseKinematics(BackendFeature):
         ----------
         robot : :class:`compas_fab.robots.Robot`
             The robot instance for which inverse kinematics is being calculated.
-        frame_WCF: :class:`compas.geometry.Frame`
+        frame_WCF : :class:`compas.geometry.Frame`
             The frame to calculate the inverse for.
-        start_configuration: :class:`compas_fab.robots.Configuration`, optional
-        group: str, optional
+        start_configuration : :class:`compas_robots.Configuration`, optional
+        group : str, optional
             The planning group used for calculation.
-        options: dict, optional
+        options : dict, optional
             Dictionary containing kwargs for arguments specific to
             the client being queried.
 
@@ -81,6 +91,9 @@ class InverseKinematics(BackendFeature):
             A tuple of 2 elements containing a list of joint positions and a list of matching joint names.
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_inverse_kinematics"
 
 
 class PlanMotion(BackendFeature):
@@ -93,12 +106,12 @@ class PlanMotion(BackendFeature):
         ----------
         robot : :class:`compas_fab.robots.Robot`
             The robot instance for which the motion path is being calculated.
-        target: :class:`compas_fab.robots.Target`
+        target : :class:`compas_fab.robots.Target`
             The goal for the robot to achieve.
-        start_configuration: :class:`compas_fab.robots.Configuration`, optional
+        start_configuration : :class:`compas_robots.Configuration`, optional
             The robot's full configuration, i.e. values for all configurable
             joints of the entire robot, at the starting position.
-        group: str, optional
+        group : str, optional
             The name of the group to plan for.
         options : dict, optional
             Dictionary containing kwargs for arguments specific to
@@ -110,6 +123,9 @@ class PlanMotion(BackendFeature):
             The calculated trajectory.
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_plan_motion.py"
 
 
 class PlanCartesianMotion(BackendFeature):
@@ -124,12 +140,12 @@ class PlanCartesianMotion(BackendFeature):
             The robot instance for which the cartesian motion path is being calculated.
         waypoints : :class:`compas_fab.robots.Waypoints`
             The waypoints for the robot to follow.
-        start_configuration: :class:`compas_robots.Configuration`, optional
+        start_configuration : :class:`compas_robots.Configuration`, optional
             The robot's full configuration, i.e. values for all configurable
             joints of the entire robot, at the starting position.
-        group: str, optional
+        group : str, optional
             The planning group used for calculation.
-        options: dict, optional
+        options : dict, optional
             Dictionary containing kwargs for arguments specific to
             the client being queried.
 
@@ -139,6 +155,9 @@ class PlanCartesianMotion(BackendFeature):
             The calculated trajectory.
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_plan_cartesian_motion.py"
 
 
 class GetPlanningScene(BackendFeature):
@@ -159,6 +178,9 @@ class GetPlanningScene(BackendFeature):
         """
         pass
 
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_get_planning_scene.py"
+
 
 class ResetPlanningScene(BackendFeature):
     """Mix-in interface for implementing a planner's reset planning scene feature."""
@@ -177,6 +199,9 @@ class ResetPlanningScene(BackendFeature):
         ``None``
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_reset_planning_scene.py"
 
 
 class AddCollisionMesh(BackendFeature):
@@ -198,6 +223,9 @@ class AddCollisionMesh(BackendFeature):
         ``None``
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_add_collision_mesh.py"
 
 
 class RemoveCollisionMesh(BackendFeature):
@@ -241,6 +269,9 @@ class AppendCollisionMesh(BackendFeature):
         """
         pass
 
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_append_collision_mesh.py"
+
 
 class AddAttachedCollisionMesh(BackendFeature):
     """Mix-in interface for implementing a planner's add attached collision mesh feature."""
@@ -262,6 +293,9 @@ class AddAttachedCollisionMesh(BackendFeature):
         """
         pass
 
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_add_attached_collision_mesh.py"
+
 
 class RemoveAttachedCollisionMesh(BackendFeature):
     """Mix-in interface for implementing a planner's remove attached collision mesh feature."""
@@ -282,3 +316,6 @@ class RemoveAttachedCollisionMesh(BackendFeature):
         ``None``
         """
         pass
+
+        # The implementation code is located in the backend's module:
+        # "src/compas_fab/backends/<backend_name>/backend_features/<planner_name>_remove_attached_collision_mesh.py"

--- a/src/compas_fab/backends/interfaces/client.py
+++ b/src/compas_fab/backends/interfaces/client.py
@@ -106,7 +106,7 @@ class PlannerInterface(object):
     """
 
     def __init__(self, client):
-        super(PlannerInterface, self).__init__()
+        # super(PlannerInterface, self).__init__()
         self.client = client
 
     # ==========================================================================

--- a/src/compas_fab/backends/kinematics/analytical_inverse_kinematics.py
+++ b/src/compas_fab/backends/kinematics/analytical_inverse_kinematics.py
@@ -103,7 +103,7 @@ class AnalyticalInverseKinematics(InverseKinematics):
         if options.get("check_collision", False) is True:
             acms = options.get("attached_collision_meshes", [])
             for acm in acms:
-                cached_robot_model = self.client.get_cached_robot(robot)
+                cached_robot_model = self.client.get_cached_robot_model(robot)
                 if not cached_robot_model.get_link_by_name(acm.collision_mesh.id):
                     self.client.add_attached_collision_mesh(acm, options={"robot": robot})
                     for touch_link in acm.touch_links:

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -1,6 +1,5 @@
 import math
 
-import compas
 from compas.geometry import argmin
 
 from compas_fab.backends.interfaces import PlanCartesianMotion

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -34,8 +34,7 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
         group : str, optional
             The planning group used for calculation.
         options : dict, optional
-            Dictionary containing kwargs for arguments specific to
-            the client being queried.
+            Dictionary containing the key-value pairs that are passed to :func:`compas_fab.robots.Robot.iter_inverse_kinematics`
 
         Returns
         -------

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -1,5 +1,6 @@
 import math
 
+import compas
 from compas.geometry import argmin
 
 from compas_fab.backends.interfaces import PlanCartesianMotion
@@ -12,12 +13,13 @@ from compas_fab.robots import PointAxisWaypoints
 
 from compas_fab.utilities import from_tcf_to_t0cf
 
-from typing import TYPE_CHECKING
+if not compas.IPY:
+    from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from typing import Optional  # noqa: F401
-    from compas_fab.robots import Robot  # noqa: F401
-    from compas_robots import Configuration  # noqa: F401
+    if TYPE_CHECKING:
+        from typing import Optional  # noqa: F401
+        from compas_fab.robots import Robot  # noqa: F401
+        from compas_robots import Configuration  # noqa: F401
 
 
 class AnalyticalPlanCartesianMotion(PlanCartesianMotion):

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -12,6 +12,13 @@ from compas_fab.robots import PointAxisWaypoints
 
 from compas_fab.utilities import from_tcf_to_t0cf
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional  # noqa: F401
+    from compas_fab.robots import Robot  # noqa: F401
+    from compas_robots import Configuration  # noqa: F401
+
 
 class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     """ """
@@ -60,6 +67,7 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     def _plan_cartesian_motion_with_frame_waypoints(
         self, robot, waypoints, start_configuration=None, group=None, options=None
     ):
+        # type: (Robot, FrameWaypoints, Optional[Configuration], Optional[str], Optional[dict]) -> JointTrajectory
         """Calculates a cartesian motion path with frame waypoints.
 
         Planner behavior:
@@ -69,7 +77,9 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
         """
         # convert the target frames to the robot's base frame
         if waypoints.tool_coordinate_frame is not None:
-            frames_WCF = [from_tcf_to_t0cf(frame, waypoints.tool_coordinate_frame) for frame in waypoints.frames]
+            frames_WCF = [from_tcf_to_t0cf(frame, waypoints.tool_coordinate_frame) for frame in waypoints.target_frames]
+        else:
+            frames_WCF = waypoints.target_frames
 
         # convert the frame WCF to RCF
         base_frame = robot.get_base_frame(group=group, full_configuration=start_configuration)
@@ -114,7 +124,8 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     def _plan_cartesian_motion_with_point_axis_waypoints(
         self, robot, waypoints, start_configuration=None, group=None, options=None
     ):
-
+        # type: (Robot, PointAxisWaypoints, Optional[Configuration], Optional[str], Optional[dict]) -> JointTrajectory
+        """Planning Cartesian motion with PointAxisWaypoints is not yet implemented in the Analytical backend."""
         raise NotImplementedError(
             "Planning Cartesian motion with PointAxisWaypoints is not yet implemented in the Analytical backend."
         )

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -10,6 +10,7 @@ from compas_fab.robots import JointTrajectory
 from compas_fab.robots import JointTrajectoryPoint
 from compas_fab.robots import FrameWaypoints
 from compas_fab.robots import PointAxisWaypoints
+from compas_fab.utilities import from_tcf_to_t0cf
 
 
 class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
@@ -64,7 +65,7 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
         Planner behavior:
         - If multiple paths are possible (i.e. due to multiple IK results), only the one that is closest to the start_configuration is returned.
         - The path is checked to ensure that the joint values are continuous and that revolution values are the smallest possible.
-        - 'stepsize' is not used to sample in between frames (i.e. no interpolation), only the input frames are used.
+        - There is no interpolation in between frames (i.e. 'max_step' parameter is not supported), only the input frames are used.
         """
         # convert the target frames to the robot's base frame
         if waypoints.tool_coordinate_frame is not None:
@@ -86,8 +87,13 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
             configurations = list(robot.iter_inverse_kinematics(frame, options=options))
             configurations_along_path.append(configurations)
 
-        # There is a maximum of 8 possible paths, corresponding to the 8 possible IK solutions for each frame
-        # The all() function is used to check if all configurations in a path are present.
+        # Analytical backend only supports robots with finite IK solutions
+        # For 6R articulated robots, there is a maximum of 8 possible paths, corresponding to the 8 possible IK solutions for each frame
+        # The `options.update({"keep_order": True})` ensures that the order of the configurations is the same across all frames
+        # but this also cause some configurations to be None, if no solution was found.
+
+        # The `all(configurations)` below is used to check if all configurations in a path are present.
+        # indicating that a complete trajectory was found.
         paths = []
         for configurations in zip(*configurations_along_path):
             if all(configurations):

--- a/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/kinematics/analytical_plan_cartesian_motion.py
@@ -11,16 +11,6 @@ from compas_fab.robots import JointTrajectoryPoint
 from compas_fab.robots import FrameWaypoints
 from compas_fab.robots import PointAxisWaypoints
 
-from compas_fab.utilities import from_tcf_to_t0cf
-
-if not compas.IPY:
-    from typing import TYPE_CHECKING
-
-    if TYPE_CHECKING:
-        from typing import Optional  # noqa: F401
-        from compas_fab.robots import Robot  # noqa: F401
-        from compas_robots import Configuration  # noqa: F401
-
 
 class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     """ """
@@ -69,7 +59,6 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     def _plan_cartesian_motion_with_frame_waypoints(
         self, robot, waypoints, start_configuration=None, group=None, options=None
     ):
-        # type: (Robot, FrameWaypoints, Optional[Configuration], Optional[str], Optional[dict]) -> JointTrajectory
         """Calculates a cartesian motion path with frame waypoints.
 
         Planner behavior:
@@ -115,9 +104,8 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
         path = paths[idx]
         path = self.smooth_configurations(path)
         trajectory = JointTrajectory()
-        trajectory.fraction = len(path) / len(
-            frames_RCF
-        )  # Technically this always be 1.0 because otherwise, the path would be rejected earlier
+        trajectory.fraction = len(path) / len(frames_RCF)
+        # Technically trajectory.fraction should always be 1.0 because otherwise, the path would be rejected earlier
         trajectory.joint_names = path[0].joint_names
         trajectory.points = [JointTrajectoryPoint(config.joint_values, config.joint_types) for config in path]
         trajectory.start_configuration = robot.merge_group_with_full_configuration(path[0], start_configuration, group)
@@ -126,7 +114,6 @@ class AnalyticalPlanCartesianMotion(PlanCartesianMotion):
     def _plan_cartesian_motion_with_point_axis_waypoints(
         self, robot, waypoints, start_configuration=None, group=None, options=None
     ):
-        # type: (Robot, PointAxisWaypoints, Optional[Configuration], Optional[str], Optional[dict]) -> JointTrajectory
         """Planning Cartesian motion with PointAxisWaypoints is not yet implemented in the Analytical backend."""
         raise NotImplementedError(
             "Planning Cartesian motion with PointAxisWaypoints is not yet implemented in the Analytical backend."

--- a/src/compas_fab/backends/pybullet/backend_features/__init__.py
+++ b/src/compas_fab/backends/pybullet/backend_features/__init__.py
@@ -1,4 +1,25 @@
+"""
+PyBullet backend features
+=========================
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    PyBulletAddAttachedCollisionMesh
+    PyBulletAddCollisionMesh
+    PyBulletAppendCollisionMesh
+    PyBulletForwardKinematics
+    PyBulletInverseKinematics
+    PyBulletRemoveAttachedCollisionMesh
+    PyBulletRemoveCollisionMesh
+
+
+
+"""
+
 from __future__ import absolute_import
+
 
 from compas_fab.backends.pybullet.backend_features.pybullet_add_attached_collision_mesh import (
     PyBulletAddAttachedCollisionMesh,
@@ -17,8 +38,8 @@ __all__ = [
     "PyBulletAddAttachedCollisionMesh",
     "PyBulletAddCollisionMesh",
     "PyBulletAppendCollisionMesh",
-    "PyBulletRemoveCollisionMesh",
-    "PyBulletRemoveAttachedCollisionMesh",
     "PyBulletForwardKinematics",
     "PyBulletInverseKinematics",
+    "PyBulletRemoveAttachedCollisionMesh",
+    "PyBulletRemoveCollisionMesh",
 ]

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_add_attached_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_add_attached_collision_mesh.py
@@ -25,9 +25,6 @@ __all__ = [
 class PyBulletAddAttachedCollisionMesh(AddAttachedCollisionMesh):
     """Callable to add a collision mesh and attach it to the robot."""
 
-    def __init__(self, client):
-        self.client = client
-
     def add_attached_collision_mesh(self, attached_collision_mesh, options=None):
         """Add a collision mesh and attach it to the robot.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_add_attached_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_add_attached_collision_mesh.py
@@ -60,7 +60,7 @@ class PyBulletAddAttachedCollisionMesh(AddAttachedCollisionMesh):
         ``None``
         """
         robot = options["robot"]
-        self.client.ensure_cached_robot_geometry(robot)
+        self.client.ensure_cached_robot_model_geometry(robot)
 
         mass = options.get("mass", 1.0)
         concavity = options.get("concavity", False)
@@ -68,7 +68,7 @@ class PyBulletAddAttachedCollisionMesh(AddAttachedCollisionMesh):
         inertial_origin = options.get("inertial_origin", Frame.worldXY())
         collision_origin = options.get("collision_origin", Frame.worldXY())
 
-        cached_robot_model = self.client.get_cached_robot(robot)
+        cached_robot_model = self.client.get_cached_robot_model(robot)
 
         # add link
         mesh = attached_collision_mesh.collision_mesh.mesh

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_add_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_add_collision_mesh.py
@@ -14,9 +14,6 @@ from compas_fab.backends.pybullet.const import STATIC_MASS
 class PyBulletAddCollisionMesh(AddCollisionMesh):
     """Callable to add a collision mesh to the planning scene."""
 
-    def __init__(self, client):
-        self.client = client
-
     def add_collision_mesh(self, collision_mesh, options=None):
         """Add a collision mesh to the planning scene.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_append_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_append_collision_mesh.py
@@ -12,9 +12,6 @@ __all__ = [
 class PyBulletAppendCollisionMesh(AppendCollisionMesh):
     """Callable to append a collision mesh to the planning scene."""
 
-    def __init__(self, client):
-        self.client = client
-
     def append_collision_mesh(self, collision_mesh, options=None):
         """Append a collision mesh to the planning scene.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
@@ -8,9 +8,6 @@ from compas_fab.backends.interfaces import ForwardKinematics
 class PyBulletForwardKinematics(ForwardKinematics):
     """Callable to calculate the robot's forward kinematic."""
 
-    def __init__(self, client):
-        self.client = client
-
     def forward_kinematics(self, robot, configuration, group=None, options=None):
         """Calculate the robot's forward kinematic.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
@@ -37,9 +37,9 @@ class PyBulletForwardKinematics(ForwardKinematics):
             The frame in the world's coordinate system (WCF).
         """
         link_name = options.get("link") or robot.get_end_effector_link_name(group)
-        cached_robot = self.client.get_cached_robot(robot)
-        body_id = self.client.get_uid(cached_robot)
-        link_id = self.client._get_link_id_by_name(link_name, cached_robot)
+        cached_robot_model = self.client.get_cached_robot_model(robot)
+        body_id = self.client.get_uid(cached_robot_model)
+        link_id = self.client._get_link_id_by_name(link_name, cached_robot_model)
         self.client.set_robot_configuration(robot, configuration, group)
         frame = self.client._get_link_frame(link_id, body_id)
         if options.get("check_collision"):

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_forward_kinematics.py
@@ -36,6 +36,8 @@ class PyBulletForwardKinematics(ForwardKinematics):
         :class:`Frame`
             The frame in the world's coordinate system (WCF).
         """
+        options = options or {"link": None, "check_collision": False}
+
         link_name = options.get("link") or robot.get_end_effector_link_name(group)
         cached_robot_model = self.client.get_cached_robot_model(robot)
         body_id = self.client.get_uid(cached_robot_model)

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -183,7 +183,6 @@ class PyBulletInverseKinematics(InverseKinematics):
         # https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/examples/inverse_kinematics_husky_kuka.py#L81
         close_enough = False
         iter = 0
-        distance = None
         joint_ids = [joint.attr["pybullet"]["id"] for joint in joints]
         body_id = kwargs["bodyUniqueId"]
         link_id = kwargs["endEffectorLinkIndex"]

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -23,9 +23,6 @@ __all__ = [
 class PyBulletInverseKinematics(InverseKinematics):
     """Callable to calculate the robot's inverse kinematics for a given frame."""
 
-    def __init__(self, client):
-        self.client = client
-
     def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
         """Calculate the robot's inverse kinematic for a given frame.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -138,7 +138,7 @@ class PyBulletInverseKinematics(InverseKinematics):
                 ik_options.update(
                     dict(
                         joints=joints,
-                        threshold=options.get("high_accuracy_threshold", 1e-6),
+                        threshold=options.get("high_accuracy_threshold", 1e-4),
                         max_iter=options.get("high_accuracy_max_iter", 20),
                     )
                 )
@@ -203,9 +203,9 @@ class PyBulletInverseKinematics(InverseKinematics):
                 target_position[2] - new_pose[2],
             ]
             # The distance is squared to avoid a sqrt operation
-            distance = diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2]
+            distance_squared = diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2]
             # Therefor, the threshold is squared as well
-            close_enough = distance < threshold * threshold
+            close_enough = distance_squared < threshold * threshold
             kwargs["restPoses"] = joint_poses
             iter += 1
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -202,8 +202,10 @@ class PyBulletInverseKinematics(InverseKinematics):
                 target_position[1] - new_pose[1],
                 target_position[2] - new_pose[2],
             ]
+            # The distance is squared to avoid a sqrt operation
             distance = diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2]
-            close_enough = distance < threshold
+            # Therefor, the threshold is squared as well
+            close_enough = distance < threshold * threshold
             kwargs["restPoses"] = joint_poses
             iter += 1
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_inverse_kinematics.py
@@ -74,12 +74,12 @@ class PyBulletInverseKinematics(InverseKinematics):
         high_accuracy = options.get("high_accuracy", True)
         max_results = options.get("max_results", 100)
         link_name = options.get("link_name") or robot.get_end_effector_link_name(group)
-        cached_robot = self.client.get_cached_robot(robot)
-        body_id = self.client.get_uid(cached_robot)
-        link_id = self.client._get_link_id_by_name(link_name, cached_robot)
+        cached_robot_model = self.client.get_cached_robot_model(robot)
+        body_id = self.client.get_uid(cached_robot_model)
+        link_id = self.client._get_link_id_by_name(link_name, cached_robot_model)
         point, orientation = pose_from_frame(frame_WCF)
 
-        joints = cached_robot.get_configurable_joints()
+        joints = cached_robot_model.get_configurable_joints()
         joints.sort(key=lambda j: j.attr["pybullet"]["id"])
         joint_names = [joint.name for joint in joints]
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_attached_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_attached_collision_mesh.py
@@ -34,9 +34,9 @@ class PyBulletRemoveAttachedCollisionMesh(RemoveAttachedCollisionMesh):
         ``None``
         """
         robot = options["robot"]
-        self.client.ensure_cached_robot_geometry(robot)
+        self.client.ensure_cached_robot_model_geometry(robot)
 
-        cached_robot_model = self.client.get_cached_robot(robot)
+        cached_robot_model = self.client.get_cached_robot_model(robot)
 
         # remove link and fixed joint
         cached_robot_model.remove_link(id)

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_attached_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_attached_collision_mesh.py
@@ -16,9 +16,6 @@ __all__ = [
 class PyBulletRemoveAttachedCollisionMesh(RemoveAttachedCollisionMesh):
     """Callable to remove an attached collision mesh from the robot."""
 
-    def __init__(self, client):
-        self.client = client
-
     def remove_attached_collision_mesh(self, id, options=None):
         """Remove an attached collision mesh from the robot.
 

--- a/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_collision_mesh.py
+++ b/src/compas_fab/backends/pybullet/backend_features/pybullet_remove_collision_mesh.py
@@ -17,9 +17,6 @@ __all__ = [
 class PyBulletRemoveCollisionMesh(RemoveCollisionMesh):
     """Callable to remove a collision mesh from the planning scene."""
 
-    def __init__(self, client):
-        self.client = client
-
     def remove_collision_mesh(self, id, options=None):
         """Remove a collision mesh from the planning scene.
 

--- a/src/compas_fab/backends/pybullet/client.py
+++ b/src/compas_fab/backends/pybullet/client.py
@@ -827,8 +827,15 @@ class PyBulletClient(PyBulletBase, ClientInterface):
 
 
 class AnalyticalPyBulletClient(PyBulletClient):
-    def inverse_kinematics(self, *args, **kwargs):
-        return AnalyticalInverseKinematics(self)(*args, **kwargs)
+    """Combination of PyBullet as the client for COllision Detection and Analytical Inverse Kinematics."""
 
-    def plan_cartesian_motion(self, *args, **kwargs):
-        return AnalyticalPlanCartesianMotion(self)(*args, **kwargs)
+    def __init__(self, connection_type="gui", verbose=False):
+        PyBulletClient.__init__(self, connection_type=connection_type, verbose=verbose)
+
+    def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
+        planner = AnalyticalInverseKinematics(self)
+        return planner.inverse_kinematics(robot, frame_WCF, start_configuration, group, options)
+
+    def plan_cartesian_motion(self, robot, waypoints, start_configuration=None, group=None, options=None):
+        planner = AnalyticalPlanCartesianMotion(self)
+        return planner.plan_cartesian_motion(robot, waypoints, start_configuration, group, options)

--- a/src/compas_fab/backends/pybullet/client.py
+++ b/src/compas_fab/backends/pybullet/client.py
@@ -218,8 +218,39 @@ class PyBulletClient(PyBulletBase, ClientInterface):
 
         return robot
 
+    def load_existing_robot(self, robot):
+        # type: (Robot) -> Robot
+        """Load an existing robot to PyBullet.
+        The robot must have its geometry and semantics loaded.
+
+        Parameters
+        ----------
+        robot : :class:`compas_fab.robots.Robot`
+            The robot to be saved for use with PyBullet.
+
+        Returns
+        -------
+        :class:`compas_fab.robots.Robot`
+            A robot instance.
+        """
+        robot.client = self
+        robot.attributes["pybullet"] = {}
+
+        robot.ensure_geometry()
+        robot.ensure_semantics()
+        self.cache_robot_model(robot)
+
+        urdf_fp = robot.attributes["pybullet"]["cached_robot_filepath"]
+        self._load_robot_to_pybullet(urdf_fp, robot)
+        self.disabled_collisions = robot.semantics.disabled_collisions
+
+        return robot
+
     def load_robot(self, urdf_file, resource_loaders=None, concavity=False, precision=None):
-        """Create a pybullet robot using the input urdf file.
+        """Create a robot from URDF and load it into PyBullet.
+
+        Robot geometry of the robot can be loaded using the resource loaders.
+        Robot semantics are loaded separately using the :meth:`load_semantics` method.
 
         Parameters
         ----------

--- a/src/compas_fab/backends/pybullet/client.py
+++ b/src/compas_fab/backends/pybullet/client.py
@@ -32,6 +32,11 @@ from .utils import redirect_stdout
 
 pybullet = LazyLoader("pybullet", globals(), "pybullet")
 
+if not compas.IPY:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from typing import list
 
 __all__ = [
     "PyBulletClient",
@@ -123,7 +128,7 @@ class PyBulletBase(object):
 class PyBulletClient(PyBulletBase, ClientInterface):
     """Interface to use pybullet as backend.
 
-    :class:`compasfab.backends.PyBulletClient` is a context manager type, so it's best
+    :class:`compas_fab.backends.PyBulletClient` is a context manager type, so it's best
     used in combination with the ``with`` statement to ensure
     resource deallocation.
 
@@ -199,9 +204,9 @@ class PyBulletClient(PyBulletBase, ClientInterface):
 
         robot.attributes["pybullet"] = {}
         if load_geometry:
-            self.cache_robot(robot, concavity)
+            self.cache_robot_model(robot, concavity)
         else:
-            robot.attributes["pybullet"]["cached_robot"] = robot.model
+            robot.attributes["pybullet"]["cached_robot_model"] = robot.model
             robot.attributes["pybullet"]["cached_robot_filepath"] = compas_fab.get(
                 "robot_library/ur5_robot/urdf/robot_description.urdf"
             )
@@ -244,9 +249,9 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         robot.attributes["pybullet"] = {}
         if resource_loaders:
             robot_model.load_geometry(*resource_loaders, precision=precision)
-            self.cache_robot(robot, concavity)
+            self.cache_robot_model(robot, concavity)
         else:
-            robot.attributes["pybullet"]["cached_robot"] = robot.model
+            robot.attributes["pybullet"]["cached_robot_model"] = robot.model
             robot.attributes["pybullet"]["cached_robot_filepath"] = urdf_file
 
         urdf_fp = robot.attributes["pybullet"]["cached_robot_filepath"]
@@ -265,20 +270,20 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         srdf_filename  : :obj:`str` or file object
             Absolute file path to the srdf file name.
         """
-        cached_robot = self.get_cached_robot(robot)
-        robot.semantics = RobotSemantics.from_srdf_file(srdf_filename, cached_robot)
+        cached_robot_model = self.get_cached_robot_model(robot)
+        robot.semantics = RobotSemantics.from_srdf_file(srdf_filename, cached_robot_model)
         self.disabled_collisions = robot.semantics.disabled_collisions
 
     def _load_robot_to_pybullet(self, urdf_file, robot):
-        cached_robot = self.get_cached_robot(robot)
+        cached_robot_model = self.get_cached_robot_model(robot)
         with redirect_stdout(enabled=not self.verbose):
             pybullet_uid = pybullet.loadURDF(
                 urdf_file, useFixedBase=True, physicsClientId=self.client_id, flags=pybullet.URDF_USE_SELF_COLLISION
             )
-            cached_robot.attr["uid"] = pybullet_uid
+            cached_robot_model.attr["uid"] = pybullet_uid
 
-        self._add_ids_to_robot_joints(cached_robot)
-        self._add_ids_to_robot_links(cached_robot)
+        self._add_ids_to_robot_joints(cached_robot_model)
+        self._add_ids_to_robot_links(cached_robot_model)
 
     def reload_from_cache(self, robot):
         """Reloads the PyBullet server with the robot's cached model.
@@ -290,7 +295,7 @@ class PyBulletClient(PyBulletBase, ClientInterface):
 
         """
         current_configuration = self.get_robot_configuration(robot)
-        cached_robot_model = self.get_cached_robot(robot)
+        cached_robot_model = self.get_cached_robot_model(robot)
         cached_robot_filepath = self.get_cached_robot_filepath(robot)
         robot_uid = self.get_uid(cached_robot_model)
         pybullet.removeBody(robot_uid, physicsClientId=self.client_id)
@@ -303,7 +308,7 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         self.set_robot_configuration(robot, current_configuration)
         self.step_simulation()
 
-    def cache_robot(self, robot, concavity=False):
+    def cache_robot_model(self, robot, concavity=False):
         """Saves an editable copy of the robot's model and its meshes
         for shadowing the state of the robot on the PyBullet server.
 
@@ -345,27 +350,28 @@ class PyBulletClient(PyBulletBase, ClientInterface):
             mesh.attrib["filename"] = address_dict[filename]
 
         # write urdf
-        cached_robot_file_name = str(robot.model.guid) + ".urdf"
-        cached_robot_filepath = os.path.join(self._cache_dir.name, cached_robot_file_name)
+        cached_robot_model_file_name = str(robot.model.guid) + ".urdf"
+        cached_robot_filepath = os.path.join(self._cache_dir.name, cached_robot_model_file_name)
         urdf.to_file(cached_robot_filepath, prettify=True)
-        cached_robot = RobotModel.from_urdf_file(cached_robot_filepath)
-        robot.attributes["pybullet"]["cached_robot"] = cached_robot
+        cached_robot_model = RobotModel.from_urdf_file(cached_robot_filepath)
+        robot.attributes["pybullet"]["cached_robot_model"] = cached_robot_model
         robot.attributes["pybullet"]["cached_robot_filepath"] = cached_robot_filepath
         robot.attributes["pybullet"]["robot_geometry_cached"] = True
 
     @staticmethod
-    def ensure_cached_robot(robot):
+    def ensure_cached_robot_model(robot):
         """Checks if a :class:`compas_fab.robots.Robot` has been cached for use with PyBullet."""
-        if not robot.attributes["pybullet"]["cached_robot"]:
+        if not robot.attributes["pybullet"]["cached_robot_model"]:
             raise Exception("This method is only callable once the robot has been cached.")
 
     @staticmethod
-    def ensure_cached_robot_geometry(robot):
+    def ensure_cached_robot_model_geometry(robot):
         """Checks if the geometry of a :class:`compas_fab.robots.Robot` has been cached for use with PyBullet."""
         if not robot.attributes["pybullet"].get("robot_geometry_cached"):
             raise Exception("This method is only callable once the robot with loaded geometry has been cached.")
 
-    def get_cached_robot(self, robot):
+    def get_cached_robot_model(self, robot):
+        # type: (Robot) -> RobotModel
         """Returns the editable copy of the robot's model for shadowing the state
         of the robot on the PyBullet server.
 
@@ -384,10 +390,11 @@ class PyBulletClient(PyBulletBase, ClientInterface):
             If the robot has not been cached.
 
         """
-        self.ensure_cached_robot(robot)
-        return robot.attributes["pybullet"]["cached_robot"]
+        self.ensure_cached_robot_model(robot)
+        return robot.attributes["pybullet"]["cached_robot_model"]
 
     def get_cached_robot_filepath(self, robot):
+        # type: (Robot) -> str
         """Returns the filepath of the editable copy of the robot's model for shadowing the state
         of the robot on the PyBullet server.
 
@@ -406,16 +413,16 @@ class PyBulletClient(PyBulletBase, ClientInterface):
             If the robot has not been cached.
 
         """
-        self.ensure_cached_robot(robot)
+        self.ensure_cached_robot_model(robot)
         return robot.attributes["pybullet"]["cached_robot_filepath"]
 
-    def get_uid(self, cached_robot):
+    def get_uid(self, cached_robot_model):
         """Returns the internal PyBullet id of the robot's model for shadowing the state
         of the robot on the PyBullet server.
 
         Parameters
         ----------
-        cached_robot : :class:`compas_robots.RobotModel`
+        cached_robot_model : :class:`compas_robots.RobotModel`
             The robot model saved for use with PyBullet.
 
         Returns
@@ -423,37 +430,37 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         :obj:`int`
 
         """
-        return cached_robot.attr["uid"]
+        return cached_robot_model.attr["uid"]
 
-    def _add_ids_to_robot_joints(self, cached_robot):
-        body_id = self.get_uid(cached_robot)
+    def _add_ids_to_robot_joints(self, cached_robot_model):
+        body_id = self.get_uid(cached_robot_model)
         joint_ids = self._get_joint_ids(body_id)
         for joint_id in joint_ids:
             joint_name = self._get_joint_name(joint_id, body_id)
-            joint = cached_robot.get_joint_by_name(joint_name)
+            joint = cached_robot_model.get_joint_by_name(joint_name)
             pybullet_attr = {"id": joint_id}
             joint.attr.setdefault("pybullet", {}).update(pybullet_attr)
 
-    def _add_ids_to_robot_links(self, cached_robot):
-        body_id = self.get_uid(cached_robot)
+    def _add_ids_to_robot_links(self, robot_model):
+        body_id = self.get_uid(robot_model)
         joint_ids = self._get_joint_ids(body_id)
         for link_id in joint_ids:
             link_name = self._get_link_name(link_id, body_id)
-            link = cached_robot.get_link_by_name(link_name)
+            link = robot_model.get_link_by_name(link_name)
             pybullet_attr = {"id": link_id}
             link.attr.setdefault("pybullet", {}).update(pybullet_attr)
 
-    def _get_joint_id_by_name(self, name, cached_robot):
-        return cached_robot.get_joint_by_name(name).attr["pybullet"]["id"]
+    def _get_joint_id_by_name(self, name, robot_model):
+        return robot_model.get_joint_by_name(name).attr["pybullet"]["id"]
 
-    def _get_joint_ids_by_name(self, names, cached_robot):
-        return tuple(self._get_joint_id_by_name(name, cached_robot) for name in names)
+    def _get_joint_ids_by_name(self, names, robot_model):
+        return tuple(self._get_joint_id_by_name(name, robot_model) for name in names)
 
-    def _get_link_id_by_name(self, name, cached_robot):
-        return cached_robot.get_link_by_name(name).attr["pybullet"]["id"]
+    def _get_link_id_by_name(self, name, robot_model):
+        return robot_model.get_link_by_name(name).attr["pybullet"]["id"]
 
-    def _get_link_ids_by_name(self, names, cached_robot):
-        return tuple(self._get_link_id_by_name(name, cached_robot) for name in names)
+    def _get_link_ids_by_name(self, names, robot_model):
+        return tuple(self._get_link_id_by_name(name, robot_model) for name in names)
 
     def filter_configurations_in_collision(self, robot, configurations):
         """Filters from a list of configurations those which are in collision.
@@ -495,10 +502,10 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         ------
         :class:`compas_fab.backends.pybullet.DetectedCollision`
         """
-        cached_robot = self.get_cached_robot(robot)
-        body_id = self.get_uid(cached_robot)
+        cached_robot_model = self.get_cached_robot_model(robot)
+        body_id = self.get_uid(cached_robot_model)
         if configuration:
-            joint_ids = self._get_joint_ids_by_name(configuration.joint_names, cached_robot)
+            joint_ids = self._get_joint_ids_by_name(configuration.joint_names, cached_robot_model)
             self._set_joint_positions(joint_ids, configuration.joint_values, body_id)
         self.check_collision_with_objects(robot)
         self.check_robot_self_collision(robot)
@@ -518,7 +525,7 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         """
         for name, body_ids in self.collision_objects.items():
             for body_id in body_ids:
-                self._check_collision(self.get_uid(self.get_cached_robot(robot)), "robot", body_id, name)
+                self._check_collision(self.get_uid(self.get_cached_robot_model(robot)), "robot", body_id, name)
 
     def check_robot_self_collision(self, robot):
         """Checks whether the robot and its attached collision objects with its current
@@ -533,15 +540,15 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         ------
         :class:`compas_fab.backends.pybullet.DetectedCollision`
         """
-        cached_robot = self.get_cached_robot(robot)
-        body_id = self.get_uid(cached_robot)
-        link_names = [link.name for link in cached_robot.iter_links() if link.collision]
+        cached_robot_model = self.get_cached_robot_model(robot)
+        body_id = self.get_uid(cached_robot_model)
+        link_names = [link.name for link in cached_robot_model.iter_links() if link.collision]
         # check for collisions between robot links
         for link_1_name, link_2_name in combinations(link_names, 2):
             if {link_1_name, link_2_name} in self.unordered_disabled_collisions:
                 continue
-            link_1_id = self._get_link_id_by_name(link_1_name, cached_robot)
-            link_2_id = self._get_link_id_by_name(link_2_name, cached_robot)
+            link_1_id = self._get_link_id_by_name(link_1_name, cached_robot_model)
+            link_2_id = self._get_link_id_by_name(link_2_name, cached_robot_model)
             self._check_collision(body_id, link_1_name, body_id, link_2_name, link_1_id, link_2_id)
 
     def check_collision_objects_for_collision(self):
@@ -603,6 +610,7 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         return pybullet.getNumJoints(body_id, physicsClientId=self.client_id)
 
     def _get_joint_ids(self, body_id):
+        # type: (int) -> list[int]
         return list(range(self._get_num_joints(body_id)))
 
     def _get_joint_name(self, joint_id, body_id):
@@ -652,11 +660,11 @@ class PyBulletClient(PyBulletBase, ClientInterface):
             The planning group used for calculation. Defaults to the robot's
             main planning group.
         """
-        cached_robot = self.get_cached_robot(robot)
-        body_id = self.get_uid(cached_robot)
+        cached_robot_model = self.get_cached_robot_model(robot)
+        body_id = self.get_uid(cached_robot_model)
         default_config = robot.zero_configuration()
         full_configuration = robot.merge_group_with_full_configuration(configuration, default_config, group)
-        joint_ids = self._get_joint_ids_by_name(full_configuration.joint_names, cached_robot)
+        joint_ids = self._get_joint_ids_by_name(full_configuration.joint_names, cached_robot_model)
         self._set_joint_positions(joint_ids, full_configuration.joint_values, body_id)
         return full_configuration
 
@@ -671,10 +679,10 @@ class PyBulletClient(PyBulletBase, ClientInterface):
         -------
         :class:`compas_robots.Configuration`
         """
-        cached_robot = self.get_cached_robot(robot)
-        body_id = self.get_uid(cached_robot)
+        cached_robot_model = self.get_cached_robot_model(robot)
+        body_id = self.get_uid(cached_robot_model)
         default_config = robot.zero_configuration()
-        joint_ids = self._get_joint_ids_by_name(default_config.joint_names, cached_robot)
+        joint_ids = self._get_joint_ids_by_name(default_config.joint_names, cached_robot_model)
         joint_values = self._get_joint_positions(joint_ids, body_id)
         default_config.joint_values = joint_values
         return default_config

--- a/src/compas_fab/backends/pybullet/planner.py
+++ b/src/compas_fab/backends/pybullet/planner.py
@@ -3,7 +3,8 @@ from __future__ import division
 from __future__ import print_function
 
 from compas_fab.backends.interfaces.client import PlannerInterface
-from compas_fab.backends.interfaces.client import forward_docstring
+
+# from compas_fab.backends.interfaces.client import forward_docstring
 from compas_fab.backends.pybullet.backend_features.pybullet_add_attached_collision_mesh import (
     PyBulletAddAttachedCollisionMesh,
 )
@@ -21,36 +22,17 @@ __all__ = [
 ]
 
 
-class PyBulletPlanner(PlannerInterface):
+class PyBulletPlanner(
+    PyBulletAddAttachedCollisionMesh,
+    PyBulletAddCollisionMesh,
+    PyBulletAppendCollisionMesh,
+    PyBulletRemoveCollisionMesh,
+    PyBulletRemoveAttachedCollisionMesh,
+    PyBulletForwardKinematics,
+    PyBulletInverseKinematics,
+    PlannerInterface,
+):
     """Implement the planner backend interface for PyBullet."""
 
     def __init__(self, client):
-        super(PyBulletPlanner, self).__init__(client)
-
-    @forward_docstring(PyBulletAddAttachedCollisionMesh)
-    def add_attached_collision_mesh(self, *args, **kwargs):
-        return PyBulletAddAttachedCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletAddCollisionMesh)
-    def add_collision_mesh(self, *args, **kwargs):
-        return PyBulletAddCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletAppendCollisionMesh)
-    def append_collision_mesh(self, *args, **kwargs):
-        return PyBulletAppendCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletRemoveCollisionMesh)
-    def remove_collision_mesh(self, *args, **kwargs):
-        return PyBulletRemoveCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletRemoveAttachedCollisionMesh)
-    def remove_attached_collision_mesh(self, *args, **kwargs):
-        return PyBulletRemoveAttachedCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletForwardKinematics)
-    def forward_kinematics(self, *args, **kwargs):
-        return PyBulletForwardKinematics(self.client)(*args, **kwargs)
-
-    @forward_docstring(PyBulletInverseKinematics)
-    def inverse_kinematics(self, *args, **kwargs):
-        return PyBulletInverseKinematics(self.client)(*args, **kwargs)
+        self.client = client

--- a/src/compas_fab/backends/ros/backend_features/__init__.py
+++ b/src/compas_fab/backends/ros/backend_features/__init__.py
@@ -1,3 +1,25 @@
+"""
+ROS backend features
+====================
+
+.. autosummary::
+    :toctree: generated/
+    :nosignatures:
+
+    MoveItAddAttachedCollisionMesh
+    MoveItAddCollisionMesh
+    MoveItAppendCollisionMesh
+    MoveItForwardKinematics
+    MoveItInverseKinematics
+    MoveItPlanCartesianMotion
+    MoveItPlanMotion
+    MoveItPlanningScene
+    MoveItRemoveAttachedCollisionMesh
+    MoveItRemoveCollisionMesh
+    MoveItResetPlanningScene
+
+"""
+
 from __future__ import absolute_import
 
 from compas_fab.backends.ros.backend_features.move_it_add_attached_collision_mesh import MoveItAddAttachedCollisionMesh

--- a/src/compas_fab/backends/ros/backend_features/move_it_add_attached_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_add_attached_collision_mesh.py
@@ -28,9 +28,6 @@ class MoveItAddAttachedCollisionMesh(AddAttachedCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def add_attached_collision_mesh(self, attached_collision_mesh, options=None):
         """Add a collision mesh and attach it to the robot.
 
@@ -56,5 +53,5 @@ class MoveItAddAttachedCollisionMesh(AddAttachedCollisionMesh):
         aco.object.operation = CollisionObject.ADD
         robot_state = RobotState(attached_collision_objects=[aco], is_diff=True)
         scene = PlanningScene(robot_state=robot_state, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_add_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_add_collision_mesh.py
@@ -27,9 +27,6 @@ class MoveItAddCollisionMesh(AddCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def add_collision_mesh(self, collision_mesh, options=None):
         """Add a collision mesh to the planning scene.
 
@@ -55,5 +52,5 @@ class MoveItAddCollisionMesh(AddCollisionMesh):
         co.operation = CollisionObject.ADD
         world = PlanningSceneWorld(collision_objects=[co])
         scene = PlanningScene(world=world, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_append_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_append_collision_mesh.py
@@ -27,9 +27,6 @@ class MoveItAppendCollisionMesh(AppendCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def append_collision_mesh(self, collision_mesh, options=None):
         """Append a collision mesh to the planning scene.
 
@@ -55,5 +52,5 @@ class MoveItAppendCollisionMesh(AppendCollisionMesh):
         co.operation = CollisionObject.APPEND
         world = PlanningSceneWorld(collision_objects=[co])
         scene = PlanningScene(world=world, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_forward_kinematics.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_forward_kinematics.py
@@ -26,9 +26,6 @@ class MoveItForwardKinematics(ForwardKinematics):
         "/compute_fk", "GetPositionFK", GetPositionFKRequest, GetPositionFKResponse, validate_response
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def forward_kinematics(self, robot, configuration, group=None, options=None):
         """Calculate the robot's forward kinematic.
 
@@ -83,9 +80,9 @@ class MoveItForwardKinematics(ForwardKinematics):
         header = Header(frame_id=base_link)
         joint_state = JointState(name=configuration.joint_names, position=configuration.joint_values, header=header)
         robot_state = RobotState(joint_state, MultiDOFJointState(header=header))
-        robot_state.filter_fields_for_distro(self.ros_client.ros_distro)
+        robot_state.filter_fields_for_distro(self.client.ros_distro)
 
         def convert_to_frame(response):
             callback(response.pose_stamped[0].pose.frame)
 
-        self.GET_POSITION_FK(self.ros_client, (header, fk_link_names, robot_state), convert_to_frame, errback)
+        self.GET_POSITION_FK(self.client, (header, fk_link_names, robot_state), convert_to_frame, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_inverse_kinematics.py
@@ -32,9 +32,6 @@ class MoveItInverseKinematics(InverseKinematics):
         "/compute_ik", "GetPositionIK", GetPositionIKRequest, GetPositionIKResponse, validate_response
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def inverse_kinematics(self, robot, frame_WCF, start_configuration=None, group=None, options=None):
         """Calculate the robot's inverse kinematic for a given frame.
 
@@ -115,7 +112,7 @@ class MoveItInverseKinematics(InverseKinematics):
                 start_state.attached_collision_objects.append(aco)
 
         # Filter needs to happen after all objects have been added
-        start_state.filter_fields_for_distro(self.ros_client.ros_distro)
+        start_state.filter_fields_for_distro(self.client.ros_distro)
 
         constraints = convert_constraints_to_rosmsg(options.get("constraints"), header)
 
@@ -135,10 +132,10 @@ class MoveItInverseKinematics(InverseKinematics):
         # The field `attempts` was removed in Noetic (and higher)
         # so it needs to be removed from the message otherwise it causes a serialization error
         # https://github.com/ros-planning/moveit/pull/1288
-        if self.ros_client.ros_distro not in (RosDistro.KINETIC, RosDistro.MELODIC):
+        if self.client.ros_distro not in (RosDistro.KINETIC, RosDistro.MELODIC):
             del ik_request.attempts
 
         def convert_to_positions(response):
             callback((response.solution.joint_state.position, response.solution.joint_state.name))
 
-        self.GET_POSITION_IK(self.ros_client, (ik_request,), convert_to_positions, errback)
+        self.GET_POSITION_IK(self.client, (ik_request,), convert_to_positions, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_cartesian_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_cartesian_motion.py
@@ -37,9 +37,6 @@ class MoveItPlanCartesianMotion(PlanCartesianMotion):
         validate_response,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def plan_cartesian_motion(self, robot, waypoints, start_configuration=None, group=None, options=None):
         """Calculates a cartesian motion path (linear in tool space).
 
@@ -137,7 +134,7 @@ class MoveItPlanCartesianMotion(PlanCartesianMotion):
                 start_state.attached_collision_objects.append(aco)
 
         # Filter needs to happen after all objects have been added
-        start_state.filter_fields_for_distro(self.ros_client.ros_distro)
+        start_state.filter_fields_for_distro(self.client.ros_distro)
 
         path_constraints = convert_constraints_to_rosmsg(options.get("path_constraints"), header)
 
@@ -162,7 +159,7 @@ class MoveItPlanCartesianMotion(PlanCartesianMotion):
             except Exception as e:
                 errback(e)
 
-        self.GET_CARTESIAN_PATH(self.ros_client, request, response_handler, errback)
+        self.GET_CARTESIAN_PATH(self.client, request, response_handler, errback)
 
     def plan_cartesian_motion_with_point_axis_waypoints_async(
         self, callback, errback, waypoints, start_configuration=None, group=None, options=None

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
@@ -29,9 +29,6 @@ class MoveItPlanMotion(PlanMotion):
         "/plan_kinematic_path", "GetMotionPlan", MotionPlanRequest, MotionPlanResponse, validate_response
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def plan_motion(self, robot, target, start_configuration=None, group=None, options=None):
         """Calculates a motion path.
 
@@ -93,6 +90,8 @@ class MoveItPlanMotion(PlanMotion):
         options["joints"] = {j.name: j.type for j in robot.model.joints}
         options["ee_link_name"] = robot.get_end_effector_link_name(group)
 
+        raise TypeError("This method is intentionally broken.")
+
         return await_callback(self.plan_motion_async, **kwargs)
 
     def plan_motion_async(self, callback, errback, target, start_configuration=None, group=None, options=None):
@@ -113,7 +112,7 @@ class MoveItPlanMotion(PlanMotion):
                 start_state.attached_collision_objects.append(aco)
 
         # Filter needs to happen after all objects have been added
-        start_state.filter_fields_for_distro(self.ros_client.ros_distro)
+        start_state.filter_fields_for_distro(self.client.ros_distro)
 
         # convert constraints
         ee_link_name = options["ee_link_name"]
@@ -150,4 +149,4 @@ class MoveItPlanMotion(PlanMotion):
             except Exception as e:
                 errback(e)
 
-        self.GET_MOTION_PLAN(self.ros_client, request, response_handler, errback)
+        self.GET_MOTION_PLAN(self.client, request, response_handler, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_plan_motion.py
@@ -90,8 +90,6 @@ class MoveItPlanMotion(PlanMotion):
         options["joints"] = {j.name: j.type for j in robot.model.joints}
         options["ee_link_name"] = robot.get_end_effector_link_name(group)
 
-        raise TypeError("This method is intentionally broken.")
-
         return await_callback(self.plan_motion_async, **kwargs)
 
     def plan_motion_async(self, callback, errback, target, start_configuration=None, group=None, options=None):

--- a/src/compas_fab/backends/ros/backend_features/move_it_planning_scene.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_planning_scene.py
@@ -22,9 +22,6 @@ class MoveItPlanningScene(GetPlanningScene):
         "/get_planning_scene", "GetPlanningScene", GetPlanningSceneRequest, GetPlanningSceneResponse
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def get_planning_scene(self, options=None):
         """Retrieve the planning scene.
 
@@ -54,4 +51,4 @@ class MoveItPlanningScene(GetPlanningScene):
                 | PlanningSceneComponents.OBJECT_COLORS
             )
         )
-        self.GET_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        self.GET_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_remove_attached_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_remove_attached_collision_mesh.py
@@ -28,9 +28,6 @@ class MoveItRemoveAttachedCollisionMesh(RemoveAttachedCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def remove_attached_collision_mesh(self, id, options=None):
         """Remove an attached collision mesh from the robot.
 
@@ -57,5 +54,5 @@ class MoveItRemoveAttachedCollisionMesh(RemoveAttachedCollisionMesh):
         aco.object.operation = CollisionObject.REMOVE
         robot_state = RobotState(attached_collision_objects=[aco], is_diff=True)
         scene = PlanningScene(robot_state=robot_state, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_remove_collision_mesh.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_remove_collision_mesh.py
@@ -27,9 +27,6 @@ class MoveItRemoveCollisionMesh(RemoveCollisionMesh):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def remove_collision_mesh(self, id, options=None):
         """Remove a collision mesh from the planning scene.
 
@@ -56,5 +53,5 @@ class MoveItRemoveCollisionMesh(RemoveCollisionMesh):
         co.operation = CollisionObject.REMOVE
         world = PlanningSceneWorld(collision_objects=[co])
         scene = PlanningScene(world=world, is_diff=True)
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/backend_features/move_it_reset_planning_scene.py
+++ b/src/compas_fab/backends/ros/backend_features/move_it_reset_planning_scene.py
@@ -25,9 +25,6 @@ class MoveItResetPlanningScene(ResetPlanningScene):
         ApplyPlanningSceneResponse,
     )
 
-    def __init__(self, ros_client):
-        self.ros_client = ros_client
-
     def reset_planning_scene(self, options=None):
         """Resets the planning scene, removing all added collision meshes.
 
@@ -46,12 +43,12 @@ class MoveItResetPlanningScene(ResetPlanningScene):
         return await_callback(self.reset_planning_scene_async, **kwargs)
 
     def reset_planning_scene_async(self, callback, errback):
-        scene = self.ros_client.get_planning_scene()
+        scene = self.client.get_planning_scene()
         for collision_object in scene.world.collision_objects:
             collision_object.operation = CollisionObject.REMOVE
         for collision_object in scene.robot_state.attached_collision_objects:
             collision_object.object["operation"] = CollisionObject.REMOVE
         scene.is_diff = True
         scene.robot_state.is_diff = True
-        request = scene.to_request(self.ros_client.ros_distro)
-        self.APPLY_PLANNING_SCENE(self.ros_client, request, callback, errback)
+        request = scene.to_request(self.client.ros_distro)
+        self.APPLY_PLANNING_SCENE(self.client, request, callback, errback)

--- a/src/compas_fab/backends/ros/planner.py
+++ b/src/compas_fab/backends/ros/planner.py
@@ -7,7 +7,8 @@ from __future__ import division
 from __future__ import print_function
 
 from compas_fab.backends.interfaces.client import PlannerInterface
-from compas_fab.backends.interfaces.client import forward_docstring
+
+# from compas_fab.backends.interfaces.client import forward_docstring
 from compas_fab.backends.ros.backend_features import MoveItResetPlanningScene
 from compas_fab.backends.ros.backend_features.move_it_add_attached_collision_mesh import MoveItAddAttachedCollisionMesh
 from compas_fab.backends.ros.backend_features.move_it_add_collision_mesh import MoveItAddCollisionMesh
@@ -27,52 +28,21 @@ __all__ = [
 ]
 
 
-class MoveItPlanner(PlannerInterface):
+class MoveItPlanner(
+    MoveItForwardKinematics,
+    MoveItInverseKinematics,
+    MoveItPlanMotion,
+    MoveItPlanCartesianMotion,
+    MoveItPlanningScene,
+    MoveItResetPlanningScene,
+    MoveItAddCollisionMesh,
+    MoveItRemoveCollisionMesh,
+    MoveItAppendCollisionMesh,
+    MoveItAddAttachedCollisionMesh,
+    MoveItRemoveAttachedCollisionMesh,
+    PlannerInterface,
+):
     """Implement the planner backend interface based on MoveIt!"""
 
     def __init__(self, client):
-        super(MoveItPlanner, self).__init__(client)
-
-    @forward_docstring(MoveItForwardKinematics)
-    def forward_kinematics(self, *args, **kwargs):
-        return MoveItForwardKinematics(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItInverseKinematics)
-    def inverse_kinematics(self, *args, **kwargs):
-        return MoveItInverseKinematics(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItPlanCartesianMotion)
-    def plan_cartesian_motion(self, *args, **kwargs):
-        return MoveItPlanCartesianMotion(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItPlanMotion)
-    def plan_motion(self, *args, **kwargs):
-        return MoveItPlanMotion(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItPlanningScene)
-    def get_planning_scene(self, *args, **kwargs):
-        return MoveItPlanningScene(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItResetPlanningScene)
-    def reset_planning_scene(self, *args, **kwargs):
-        return MoveItResetPlanningScene(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItAddCollisionMesh)
-    def add_collision_mesh(self, *args, **kwargs):
-        return MoveItAddCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItRemoveCollisionMesh)
-    def remove_collision_mesh(self, *args, **kwargs):
-        return MoveItRemoveCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItAppendCollisionMesh)
-    def append_collision_mesh(self, *args, **kwargs):
-        return MoveItAppendCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItAddAttachedCollisionMesh)
-    def add_attached_collision_mesh(self, *args, **kwargs):
-        return MoveItAddAttachedCollisionMesh(self.client)(*args, **kwargs)
-
-    @forward_docstring(MoveItRemoveAttachedCollisionMesh)
-    def remove_attached_collision_mesh(self, *args, **kwargs):
-        return MoveItRemoveAttachedCollisionMesh(self.client)(*args, **kwargs)
+        self.client = client

--- a/src/compas_fab/backends/ros/planner.py
+++ b/src/compas_fab/backends/ros/planner.py
@@ -1,5 +1,6 @@
 """
 Internal implementation of the planner backend interface for MoveIt!
+
 """
 
 from __future__ import absolute_import

--- a/src/compas_fab/ghpython/components/Cf_PlanCartesianMotion/code.py
+++ b/src/compas_fab/ghpython/components/Cf_PlanCartesianMotion/code.py
@@ -9,6 +9,7 @@ from ghpythonlib.componentbase import executingcomponent as component
 from scriptcontext import sticky as st
 
 from compas_fab.ghpython.components import create_id
+from compas_fab.robots import FrameWaypoints
 
 
 class PlanCartesianMotion(component):
@@ -23,8 +24,9 @@ class PlanCartesianMotion(component):
 
         if robot and robot.client and robot.client.is_connected and start_configuration and planes and compute:
             frames = [plane_to_compas_frame(plane) for plane in planes]
+            frame_waypoints = FrameWaypoints(frames)
             st[key] = robot.plan_cartesian_motion(
-                frames,
+                frame_waypoints,
                 start_configuration=start_configuration,
                 group=group,
                 options=dict(

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -393,6 +393,9 @@ class Robot(Data):
     def get_link_names_with_collision_geometry(self):
         """Get the names of the links with collision geometry.
 
+        Note that returned names does not imply that the link has collision geometry loaded.
+        Use :meth:`ensure_geometry()` to ensure that collision geometry is loaded.
+
         Returns
         -------
         :obj:`list` of :obj:`str`

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1415,9 +1415,7 @@ class Robot(Data):
                 else:
                     cp.scale(1.0 / self.scale_factor)
                 path_constraints_WCF_scaled.append(cp)
-        else:
-            path_constraints_WCF_scaled = None
-        options["path_constraints"] = path_constraints_WCF_scaled
+            options["path_constraints"] = path_constraints_WCF_scaled
 
         # =====================
         # Attached CM and Tools

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1321,8 +1321,9 @@ class Robot(Data):
         ----------
         waypoints : :class:`compas_fab.robots.Waypoints`
             The waypoints for the robot to follow.
-            If a tool is attached to the robot, the :meth:`~compas_fab.robots.Waypoints.tool_coordinate_frame` parameter
-            should be set.
+            For more information on how to define waypoints, see :ref:`waypoints`.
+            In addition, note that not all planning backends support all waypoint types,
+            check documentation of the backend in use for more details.
         start_configuration : :class:`compas_robots.Configuration`, optional
             The robot's full configuration, i.e. values for all configurable
             joints of the entire robot, at the start of the motion.

--- a/src/compas_fab/robots/robot.py
+++ b/src/compas_fab/robots/robot.py
@@ -1374,8 +1374,9 @@ class Robot(Data):
         True
         """
         # The plan_cartesian_motion method in the Robot class is a wrapper around planing backend's
-        # plan_cartesian_motion method. This method is responsible for scaling the waypoints, start_configuration,
-        # options and the planned trajectory.
+        # plan_cartesian_motion method. This method is responsible for scaling the waypoints, start_configuration and the planned trajectory.
+        # Some options may also need scaling, like max_step. This should be removed in the future.
+        # TODO: Discuss if we can have all options passed with a fixed unit to avoid scaling.
         # Attached tools are also managed by this function.
 
         options = options or {}

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -497,6 +497,8 @@ class Waypoints(Data):
     ----------
     name : str , optional, default = 'target'
         A human-readable name for identifying the target.
+    tool_coordinate_frame : :class:`compas.geometry.Frame` or :class:`compas.geometry.Transformation`
+        The tool tip coordinate frame relative to the flange of the robot.
 
     See Also
     --------
@@ -509,7 +511,7 @@ class Waypoints(Data):
         self.name = name
 
     @property
-    def __data__(self):
+    def tool_coordinate_frame(self):
         raise NotImplementedError
 
     def scaled(self, factor):
@@ -687,6 +689,8 @@ class PointAxisWaypoints(Waypoints):
         super(PointAxisWaypoints, self).__init__(name=name)
         self.target_points_and_axes = target_points_and_axes
         self.tolerance_position = tolerance_position
+        if isinstance(tool_coordinate_frame, Transformation):
+            tool_coordinate_frame = Frame.from_transformation(tool_coordinate_frame)
         self.tool_coordinate_frame = tool_coordinate_frame
 
     @property

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -3,6 +3,12 @@ from compas.geometry import Frame
 from compas.geometry import Transformation
 from compas_robots.model import Joint
 
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from compas_robots import Configuration  # noqa: F401
+
 __all__ = [
     "Target",
     "FrameTarget",
@@ -230,7 +236,7 @@ class PointAxisTarget(Target):
         The tool tip coordinate frame relative to the flange coordinate frame of the robot.
         If not specified, the target point is relative to the robot's flange (T0CF) and the
         Z axis of the flange can rotate around the target axis.
-    nane : str, optional
+    name : str, optional
         The human-readable name of the target.
         Defaults to 'Point-Axis Target'.
     """
@@ -497,7 +503,7 @@ class Waypoints(Data):
     ----------
     name : str , optional, default = 'target'
         A human-readable name for identifying the target.
-    tool_coordinate_frame : :class:`compas.geometry.Frame` or :class:`compas.geometry.Transformation`
+    tool_coordinate_frame : :class:`compas.geometry.Frame` or :class:`compas.geometry.Transformation`, optional
         The tool tip coordinate frame relative to the flange of the robot.
 
     See Also
@@ -509,6 +515,9 @@ class Waypoints(Data):
     def __init__(self, tool_coordinate_frame, name="Generic Waypoints"):
         super(Waypoints, self).__init__()
         self.name = name
+        # If the user provides a transformation, convert it to a Frame
+        if isinstance(tool_coordinate_frame, Transformation):
+            tool_coordinate_frame = Frame.from_transformation(tool_coordinate_frame)
         self.tool_coordinate_frame = tool_coordinate_frame
 
     def scaled(self, factor):
@@ -566,13 +575,10 @@ class FrameWaypoints(Waypoints):
         tool_coordinate_frame=None,
         name="Frame Waypoints",
     ):
-        super(FrameWaypoints, self).__init__(name=name)
+        super(FrameWaypoints, self).__init__(tool_coordinate_frame=tool_coordinate_frame, name=name)
         self.target_frames = target_frames
         self.tolerance_position = tolerance_position
         self.tolerance_orientation = tolerance_orientation
-        if isinstance(tool_coordinate_frame, Transformation):
-            tool_coordinate_frame = Frame.from_transformation(tool_coordinate_frame)
-        self.tool_coordinate_frame = tool_coordinate_frame
 
     @property
     def __data__(self):
@@ -666,7 +672,7 @@ class PointAxisWaypoints(Waypoints):
     tolerance_position : float, optional
         The tolerance for the position of the target point.
         If not specified, the default value from the planner is used.
-    tool_coordinate_frame : :class:`compas.geometry.Frame`, optional
+    tool_coordinate_frame : :class:`compas.geometry.Frame` or :class:`compas.geometry.Transformation`, optional
         The tool tip coordinate frame relative to the flange coordinate frame of the robot.
         If not specified, the target point is relative to the robot's flange (T0CF) and the
         Z axis of the flange can rotate around the target axis.
@@ -683,12 +689,9 @@ class PointAxisWaypoints(Waypoints):
         tool_coordinate_frame=None,
         name="Point-Axis Waypoints",
     ):
-        super(PointAxisWaypoints, self).__init__(name=name)
+        super(PointAxisWaypoints, self).__init__(tool_coordinate_frame=tool_coordinate_frame, name=name)
         self.target_points_and_axes = target_points_and_axes
         self.tolerance_position = tolerance_position
-        if isinstance(tool_coordinate_frame, Transformation):
-            tool_coordinate_frame = Frame.from_transformation(tool_coordinate_frame)
-        self.tool_coordinate_frame = tool_coordinate_frame
 
     @property
     def __data__(self):

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -5,12 +5,6 @@ from compas.geometry import Frame
 from compas.geometry import Transformation
 from compas_robots.model import Joint
 
-if not compas.IPY:
-    from typing import TYPE_CHECKING
-
-    if TYPE_CHECKING:
-        from compas_robots import Configuration  # noqa: F401
-
 __all__ = [
     "Target",
     "FrameTarget",
@@ -190,7 +184,7 @@ class FrameTarget(Target):
         """
         target_frame = self.target_frame.scaled(factor)
         tolerance_position = self.tolerance_position * factor
-        tolerance_orientation = self.tolerance_orientation * factor
+        tolerance_orientation = self.tolerance_orientation
         tool_coordinate_frame = self.tool_coordinate_frame.scaled(factor) if self.tool_coordinate_frame else None
         return FrameTarget(target_frame, tolerance_position, tolerance_orientation, tool_coordinate_frame, self.name)
 

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -30,9 +30,9 @@ class Target(Data):
     pose, configuration, and joint constraints. Dynamic targets such as
     velocity, acceleration, and jerk are not yet supported.
 
-    Waypoints are intended to be used for motion planning with a planning backend by using :meth:`compas_fab.robot.plan_motion`.
-    Different backends might support different types of
-    targets.
+    Targets are intended to be used for motion planning with a planning backend
+    by using :meth:`compas_fab.robot.plan_motion`.
+    Note that different backends support different types of targets.
 
     Attributes
     ----------
@@ -497,8 +497,8 @@ class Waypoints(Data):
     Waypoints are useful for tasks like painting, welding, or 3D printing, where the programmer
     wants to define the waypoints the robot should pass through.
 
-    Waypoints are intended to be used for motion planning with a planning backend by using :meth:`compas_fab.robot.plan_motion_with_waypoints`.
-    Different backends might support different types of waypoints.
+    Waypoints are intended to be used for motion planning with a planning backend by using :meth:`compas_fab.robot.plan_cartesian_motion`.
+    Note that different backends support different types of waypoints.
     The method of interpolation between the waypoints is controlled by the motion planner backend.
 
     Attributes

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -1,5 +1,3 @@
-import compas
-
 from compas.data import Data
 from compas.geometry import Frame
 from compas.geometry import Transformation

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -1,13 +1,15 @@
+import compas
+
 from compas.data import Data
 from compas.geometry import Frame
 from compas.geometry import Transformation
 from compas_robots.model import Joint
 
+if not compas.IPY:
+    from typing import TYPE_CHECKING
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from compas_robots import Configuration  # noqa: F401
+    if TYPE_CHECKING:
+        from compas_robots import Configuration  # noqa: F401
 
 __all__ = [
     "Target",

--- a/src/compas_fab/robots/targets.py
+++ b/src/compas_fab/robots/targets.py
@@ -506,13 +506,10 @@ class Waypoints(Data):
     :class:`FrameWaypoints`
     """
 
-    def __init__(self, name="Generic Waypoints"):
+    def __init__(self, tool_coordinate_frame, name="Generic Waypoints"):
         super(Waypoints, self).__init__()
         self.name = name
-
-    @property
-    def tool_coordinate_frame(self):
-        raise NotImplementedError
+        self.tool_coordinate_frame = tool_coordinate_frame
 
     def scaled(self, factor):
         """Returns a scaled copy of the waypoints.

--- a/tests/backends/kinematics/test_inverse_kinematics.py
+++ b/tests/backends/kinematics/test_inverse_kinematics.py
@@ -150,4 +150,6 @@ def test_kinematics_cartesian_with_tool_coordinate_frame(frame_waypoints):
         # Assert that the trajectory is complete
         assert trajectory.fraction == 1.0
         # Assert that the trajectory has the correct number of points
+        # NOTE: At the moment the AnalyticalPyBulletClient does not perform any interpolation between frames
+        # NOTE: if future implementation fixes this, the following test will not be valid anymore
         assert len(trajectory.points) == len(frame_waypoints.target_frames)

--- a/tests/backends/pybullet/test_pybullet_client.py
+++ b/tests/backends/pybullet/test_pybullet_client.py
@@ -12,11 +12,6 @@ def test_pybullet_client_connection_direct():
         assert client.is_connected
 
 
-def test_pybullet_client_connection_gui():
-    with PyBulletClient(connection_type="gui") as client:
-        assert client.is_connected
-
-
 def test_pybullet_client_load_robot():
     with PyBulletClient(connection_type="direct") as client:
         urdf_filename = compas_fab.get("robot_library/ur5_robot/urdf/robot_description.urdf")

--- a/tests/backends/pybullet/test_pybullet_client.py
+++ b/tests/backends/pybullet/test_pybullet_client.py
@@ -1,0 +1,70 @@
+import compas_fab
+import pytest
+
+from compas_fab.backends import PyBulletClient
+from compas_robots import RobotModel
+
+from compas_robots.resources import LocalPackageMeshLoader
+
+
+def test_pybullet_client_connection_direct():
+    with PyBulletClient(connection_type="direct") as client:
+        assert client.is_connected
+
+
+def test_pybullet_client_connection_gui():
+    with PyBulletClient(connection_type="gui") as client:
+        assert client.is_connected
+
+
+def test_pybullet_client_load_robot():
+    with PyBulletClient(connection_type="direct") as client:
+        urdf_filename = compas_fab.get("robot_library/ur5_robot/urdf/robot_description.urdf")
+        robot = client.load_robot(urdf_filename)
+        assert robot is not None
+        assert robot.name == "ur5_robot"
+        # Check that the RobotModel is present
+        assert isinstance(robot.model, RobotModel)
+        # Check that the robot do not have any geometry
+        with pytest.raises(Exception):
+            robot.ensure_geometry()
+
+
+def test_pybullet_client_load_robot_with_meshes():
+    with PyBulletClient(connection_type="direct") as client:
+        urdf_filename = compas_fab.get("robot_library/ur5_robot/urdf/robot_description.urdf")
+        mesh_loader = LocalPackageMeshLoader(compas_fab.get("robot_library/ur5_robot"), "")
+        robot = client.load_robot(urdf_filename, [mesh_loader])
+        assert robot is not None
+        assert robot.name == "ur5_robot"
+        assert isinstance(robot.model, RobotModel)
+        link_names = robot.get_link_names_with_collision_geometry()
+        assert set(link_names) == set(
+            [
+                "base_link_inertia",
+                "shoulder_link",
+                "upper_arm_link",
+                "forearm_link",
+                "wrist_1_link",
+                "wrist_2_link",
+                "wrist_3_link",
+            ]
+        )
+        # Check that the robot has geometry
+        robot.ensure_geometry()
+
+
+def test_pybullet_client_load_robot_with_sementics():
+    with PyBulletClient(connection_type="direct") as client:
+        urdf_filename = compas_fab.get("robot_library/ur5_robot/urdf/robot_description.urdf")
+        mesh_loader = LocalPackageMeshLoader(compas_fab.get("robot_library/ur5_robot"), "")
+        robot = client.load_robot(urdf_filename, [mesh_loader])
+        srdf_filename = compas_fab.get("robot_library/ur5_robot/robot_description_semantic.srdf")
+        client.load_semantics(robot, srdf_filename)
+        # Check that the robot has geometry
+        robot.ensure_geometry()
+        # Check that the robot has semantics
+        robot.ensure_semantics()
+
+
+# TODO: After implementing the stateless backend, we should test methods related to planning scene and scene state management.

--- a/tests/backends/pybullet/test_pybullet_planner.py
+++ b/tests/backends/pybullet/test_pybullet_planner.py
@@ -1,0 +1,252 @@
+from compas_fab.backends import PyBulletClient
+from compas_fab.backends import PyBulletPlanner
+from compas.geometry import Point
+from compas.geometry import Vector
+from compas.geometry import Frame
+
+from compas.tolerance import Tolerance
+from compas_fab.robots import RobotLibrary
+
+# The tolerance for the tests are set to 1e-4 meters, equivalent to 0.1 mm
+TOL = Tolerance(unit="m", absolute=1e-4, relative=1e-4)
+
+
+def validate_planner_model_fk_with_truth(planner_result, model_result, true_result):
+    """Helper function to validate planner results with known truth and model results
+
+    Planner result comes from the planning backend.
+    Model result comes from the RobotModel FK calculation.
+    True result is the known ground truth result.
+    """
+    # Check with known ground truth result
+    assert TOL.is_allclose(
+        planner_result.point, true_result.point
+    ), f"Planner Result Pt {planner_result.point} != Known Truth Pt{true_result.point}"
+    assert TOL.is_allclose(
+        planner_result.xaxis, true_result.xaxis
+    ), f"Planner Result X {planner_result.xaxis} != Known Truth X {true_result.xaxis}"
+    assert TOL.is_allclose(
+        planner_result.yaxis, true_result.yaxis
+    ), f"Planner Result Y {planner_result.yaxis} != Known Truth Y {true_result.yaxis}"
+    # Check with RobotModel FK result
+    assert TOL.is_allclose(
+        model_result.point, true_result.point
+    ), f"Model Result Pt {model_result.point} != Known Truth Pt {true_result.point}"
+    assert TOL.is_allclose(
+        model_result.xaxis, true_result.xaxis
+    ), f"Model Result X {model_result.xaxis} != Known Truth X {true_result.xaxis}"
+    assert TOL.is_allclose(
+        model_result.yaxis, true_result.yaxis
+    ), f"Model Result Y {model_result.yaxis} != Known Truth Y {true_result.yaxis}"
+
+
+def validate_ik_with_fk(ik_target_frame, fk_result_frame):
+    # Check if the IK target frame is close to the FK result frame
+    assert TOL.is_allclose(
+        ik_target_frame.point, fk_result_frame.point
+    ), f"IK Target Pt {ik_target_frame.point} != FK Result Pt {fk_result_frame.point}"
+    assert TOL.is_allclose(
+        ik_target_frame.xaxis, fk_result_frame.xaxis
+    ), f"IK Target X {ik_target_frame.xaxis} != FK Result X {fk_result_frame.xaxis}"
+    assert TOL.is_allclose(
+        ik_target_frame.yaxis, fk_result_frame.yaxis
+    ), f"IK Target Y {ik_target_frame.yaxis} != FK Result Y {fk_result_frame.yaxis}"
+
+
+def _test_fk_with_pybullet_planner(robot, true_result):
+    with PyBulletClient(connection_type="direct") as client:
+        robot = client.load_existing_robot(robot)
+        planner = PyBulletPlanner(client)
+
+        planning_group = robot.main_group_name
+        end_effector_link = robot.get_end_effector_link_name(planning_group)
+
+        planner_fk_result = planner.forward_kinematics(robot, robot.zero_configuration(), planning_group)
+        print(planner_fk_result)
+        model_fk_result = robot.model.forward_kinematics(robot.zero_configuration(), end_effector_link)
+        print(model_fk_result)
+
+        validate_planner_model_fk_with_truth(planner_fk_result, model_fk_result, true_result)
+
+
+def test_pybullet_planner_fk_ur5():
+    robot = RobotLibrary.ur5(load_geometry=True)
+    true_result = Frame(
+        point=Point(x=0.8172500133514404, y=0.19144999980926514, z=-0.005491000134497881),
+        xaxis=Vector(x=-1.0, y=0.0, z=0.0),
+        yaxis=Vector(x=0.0, y=0.0, z=1.0),
+    )
+    _test_fk_with_pybullet_planner(robot, true_result)
+
+
+def test_pybullet_planner_fk_abb_irb4600_40_255():
+    robot = RobotLibrary.abb_irb4600_40_255(load_geometry=True)
+    true_result = Frame(
+        point=Point(x=1.58, y=0.0, z=1.765),
+        xaxis=Vector(x=0.0, y=0.0, z=-1.0),
+        yaxis=Vector(x=0.0, y=1.0, z=0.0),
+    )
+    _test_fk_with_pybullet_planner(robot, true_result)
+
+
+def test_pybullet_planner_fk_ur10e():
+    robot = RobotLibrary.ur10e(load_geometry=True)
+    true_result = Frame(
+        point=Point(x=1.18425, y=0.2907, z=0.0608),
+        xaxis=Vector(x=-1.0, y=0.0, z=-0.0),
+        yaxis=Vector(x=0.0, y=0.0, z=1.0),
+    )
+    _test_fk_with_pybullet_planner(robot, true_result)
+
+
+######################################################
+# Testing the IK-FK agreement for the PyBullet backend
+######################################################
+
+
+def _test_pybullet_ik_fk_agreement(robot, ik_target_frames):
+    # These options are set to ensure that the IK solver converges to a high accuracy
+    # Threshold is set to 1e-5 meters to be larger than the tolerance used for comparison (1e-4 meters)
+    ik_options = {"high_accuracy_max_iter": 50, "high_accuracy": True, "high_accuracy_threshold": 1e-5}
+
+    with PyBulletClient(connection_type="direct") as client:
+        robot = client.load_existing_robot(robot)
+        planner = PyBulletPlanner(client)
+        planning_group = robot.main_group_name
+        for ik_target_frame in ik_target_frames:
+            # IK Query to the planner (Frame to Configuration)
+            try:
+                # Note: The inverse_kinematics method returns a generator
+                joint_positions, joint_names = next(
+                    planner.inverse_kinematics(
+                        robot,
+                        ik_target_frame,
+                        start_configuration=robot.zero_configuration(),
+                        group=planning_group,
+                        options=ik_options,
+                    )
+                )
+            except StopIteration:
+                assert False, f"No IK Solution found for frame {ik_target_frame}"
+
+            # Reconstruct the full Configuration from the returned joint positions
+            ik_result = robot.zero_configuration()
+            for name, value in zip(joint_names, joint_positions):
+                ik_result[name] = value
+
+            # FK Query to the planner (Configuration to Frame)
+            fk_result = planner.forward_kinematics(robot, ik_result, planning_group)
+
+            # Compare the frames
+            validate_ik_with_fk(ik_target_frame, fk_result)
+
+
+def test_pybullet_ik_fk_agreement_ur5():
+    robot = RobotLibrary.ur5(load_geometry=True)
+
+    ik_center_frame = Frame(
+        Point(x=0.4, y=0.1, z=0.3),
+        Vector(x=-1.0, y=0.0, z=0.0),
+        Vector(x=0.0, y=0.0, z=1.0),
+    )
+
+    ik_target_frames = []
+    ik_target_frames.append(ik_center_frame)
+    ik_target_frames.append(ik_center_frame.translated(Vector(-0.01, -0.01, -0.01)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(0.0, 0.01, 0.0)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(0.0, 0.0, 0.01)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(0.1, 0.1, 0.2)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(-0.1, -0.1, 0.0)))
+
+    _test_pybullet_ik_fk_agreement(robot, ik_target_frames)
+
+
+def test_pybullet_ik_fk_agreement_ur10e():
+    robot = RobotLibrary.ur10e(load_geometry=True)
+
+    ik_center_frame = Frame(
+        Point(x=0.4, y=0.1, z=0.3),
+        Vector(x=-1.0, y=0.0, z=0.0),
+        Vector(x=0.0, y=0.0, z=1.0),
+    )
+
+    ik_target_frames = []
+    ik_target_frames.append(ik_center_frame)
+    ik_target_frames.append(ik_center_frame.translated(Vector(-0.01, -0.01, -0.01)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(0.0, 0.01, 0.0)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(0.0, 0.0, 0.01)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(0.1, 0.1, 0.2)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(-0.1, -0.1, 0.0)))
+
+    _test_pybullet_ik_fk_agreement(robot, ik_target_frames)
+
+
+def test_pybullet_ik_fk_agreement_abb_irb4600_40_255():
+    robot = RobotLibrary.abb_irb4600_40_255(load_geometry=True)
+
+    ik_center_frame = Frame(
+        Point(x=1.0, y=0.3, z=1.3),
+        Vector(x=-1.0, y=0.0, z=0.0),
+        Vector(x=0.0, y=0.0, z=1.0),
+    )
+
+    ik_target_frames = []
+    ik_target_frames.append(ik_center_frame)
+    ik_target_frames.append(ik_center_frame.translated(Vector(-0.1, -0.1, -0.1)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(0.0, 0.1, 0.0)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(0.0, 0.0, 0.1)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(0.1, 0.1, 0.2)))
+    ik_target_frames.append(ik_center_frame.translated(Vector(-0.3, -0.1, -0.3)))
+
+    _test_pybullet_ik_fk_agreement(robot, ik_target_frames)
+
+
+##################################################
+# Testing IK out of reach for the PyBullet backend
+##################################################
+
+
+def test_pybullet_ik_out_of_reach_ur5():
+    robot = RobotLibrary.ur5(load_geometry=True)
+
+    ik_target_frames = []
+
+    ik_target_frames.append(
+        Frame(
+            Point(x=2.4, y=0.1, z=0.3),
+            Vector(x=-1.0, y=0.0, z=0.0),
+            Vector(x=0.0, y=0.0, z=1.0),
+        )
+    )
+    ik_target_frames.append(
+        Frame(
+            Point(x=0.4, y=1.5, z=0.3),
+            Vector(x=-1.0, y=0.0, z=0.0),
+            Vector(x=0.0, y=0.0, z=1.0),
+        )
+    )
+
+    # high_accuracy_max_iter is set to 20 to reduce the number of iterations, faster testing time.
+    ik_options = {"high_accuracy_max_iter": 20, "high_accuracy": True, "high_accuracy_threshold": 1e-5}
+
+    with PyBulletClient(connection_type="direct") as client:
+        robot = client.load_existing_robot(robot)
+        planner = PyBulletPlanner(client)
+        planning_group = robot.main_group_name
+        for ik_target_frame in ik_target_frames:
+            # IK Query to the planner (Frame to Configuration)
+            try:
+                # Note: The inverse_kinematics method returns a generator
+                joint_positions, joint_names = next(
+                    planner.inverse_kinematics(
+                        robot,
+                        ik_target_frame,
+                        start_configuration=robot.zero_configuration(),
+                        group=planning_group,
+                        options=ik_options,
+                    )
+                )
+                # An error should be thrown here because the IK target is out of reach
+                assert False, f"IK Solution found when there should be none: frame {ik_target_frame}"
+            except StopIteration:
+                continue

--- a/tests/backends/pybullet/test_pybullet_planner.py
+++ b/tests/backends/pybullet/test_pybullet_planner.py
@@ -8,7 +8,9 @@ from compas.tolerance import Tolerance
 from compas_fab.robots import RobotLibrary
 
 # The tolerance for the tests are set to 1e-4 meters, equivalent to 0.1 mm
-TOL = Tolerance(unit="m", absolute=1e-4, relative=1e-4)
+# Relative tolerance is set to 1e-3 (0.1%)
+# Angular tolerance is set to 2e-3 radians, equivalent to 0.11 degrees
+TOL = Tolerance(unit="m", absolute=1e-4, relative=1e-3, angular=2e-3)
 
 
 def validate_planner_model_fk_with_truth(planner_result, model_result, true_result):
@@ -22,22 +24,22 @@ def validate_planner_model_fk_with_truth(planner_result, model_result, true_resu
     assert TOL.is_allclose(
         planner_result.point, true_result.point
     ), f"Planner Result Pt {planner_result.point} != Known Truth Pt{true_result.point}"
-    assert TOL.is_allclose(
-        planner_result.xaxis, true_result.xaxis
-    ), f"Planner Result X {planner_result.xaxis} != Known Truth X {true_result.xaxis}"
-    assert TOL.is_allclose(
-        planner_result.yaxis, true_result.yaxis
-    ), f"Planner Result Y {planner_result.yaxis} != Known Truth Y {true_result.yaxis}"
+    assert TOL.is_angle_zero(
+        planner_result.xaxis.angle(true_result.xaxis)
+    ), f"Planner Result X {planner_result.xaxis} angle with Known Truth X {true_result.xaxis}"
+    assert TOL.is_angle_zero(
+        planner_result.yaxis.angle(true_result.yaxis)
+    ), f"Planner Result Y {planner_result.yaxis} angle with Known Truth Y {true_result.yaxis}"
     # Check with RobotModel FK result
     assert TOL.is_allclose(
         model_result.point, true_result.point
     ), f"Model Result Pt {model_result.point} != Known Truth Pt {true_result.point}"
-    assert TOL.is_allclose(
-        model_result.xaxis, true_result.xaxis
-    ), f"Model Result X {model_result.xaxis} != Known Truth X {true_result.xaxis}"
-    assert TOL.is_allclose(
-        model_result.yaxis, true_result.yaxis
-    ), f"Model Result Y {model_result.yaxis} != Known Truth Y {true_result.yaxis}"
+    assert TOL.is_angle_zero(
+        model_result.xaxis.angle(true_result.xaxis)
+    ), f"Model Result X {model_result.xaxis} angle with Known Truth X {true_result.xaxis}"
+    assert TOL.is_angle_zero(
+        model_result.yaxis.angle(true_result.yaxis)
+    ), f"Model Result Y {model_result.yaxis} angle with Known Truth Y {true_result.yaxis}"
 
 
 def validate_ik_with_fk(ik_target_frame, fk_result_frame):
@@ -45,12 +47,12 @@ def validate_ik_with_fk(ik_target_frame, fk_result_frame):
     assert TOL.is_allclose(
         ik_target_frame.point, fk_result_frame.point
     ), f"IK Target Pt {ik_target_frame.point} != FK Result Pt {fk_result_frame.point}"
-    assert TOL.is_allclose(
-        ik_target_frame.xaxis, fk_result_frame.xaxis
-    ), f"IK Target X {ik_target_frame.xaxis} != FK Result X {fk_result_frame.xaxis}"
-    assert TOL.is_allclose(
-        ik_target_frame.yaxis, fk_result_frame.yaxis
-    ), f"IK Target Y {ik_target_frame.yaxis} != FK Result Y {fk_result_frame.yaxis}"
+    assert TOL.is_angle_zero(
+        ik_target_frame.xaxis.angle(fk_result_frame.xaxis)
+    ), f"IK Target X {ik_target_frame.xaxis} angle with FK Result X {fk_result_frame.xaxis} > tolerance"
+    assert TOL.is_angle_zero(
+        ik_target_frame.yaxis.angle(fk_result_frame.yaxis)
+    ), f"IK Target Y {ik_target_frame.yaxis} angle with FK Result Y {fk_result_frame.yaxis} > tolerance"
 
 
 def _test_fk_with_pybullet_planner(robot, true_result):

--- a/tests/backends/pybullet/test_pybullet_planner.py
+++ b/tests/backends/pybullet/test_pybullet_planner.py
@@ -1,5 +1,9 @@
-from compas_fab.backends import PyBulletClient
-from compas_fab.backends import PyBulletPlanner
+import compas
+
+if not compas.IPY:
+    from compas_fab.backends import PyBulletClient
+    from compas_fab.backends import PyBulletPlanner
+
 from compas.geometry import Point
 from compas.geometry import Vector
 from compas.geometry import Frame
@@ -20,26 +24,27 @@ def validate_planner_model_fk_with_truth(planner_result, model_result, true_resu
     Model result comes from the RobotModel FK calculation.
     True result is the known ground truth result.
     """
+
     # Check with known ground truth result
     assert TOL.is_allclose(
         planner_result.point, true_result.point
     ), f"Planner Result Pt {planner_result.point} != Known Truth Pt{true_result.point}"
     assert TOL.is_angle_zero(
         planner_result.xaxis.angle(true_result.xaxis)
-    ), f"Planner Result X {planner_result.xaxis} angle with Known Truth X {true_result.xaxis}"
+    ), f"Planner Result X {planner_result.xaxis} angle discrepancy with Known Truth X {true_result.xaxis}"
     assert TOL.is_angle_zero(
         planner_result.yaxis.angle(true_result.yaxis)
-    ), f"Planner Result Y {planner_result.yaxis} angle with Known Truth Y {true_result.yaxis}"
+    ), f"Planner Result Y {planner_result.yaxis} angle discrepancy with Known Truth Y {true_result.yaxis}"
     # Check with RobotModel FK result
     assert TOL.is_allclose(
         model_result.point, true_result.point
     ), f"Model Result Pt {model_result.point} != Known Truth Pt {true_result.point}"
     assert TOL.is_angle_zero(
         model_result.xaxis.angle(true_result.xaxis)
-    ), f"Model Result X {model_result.xaxis} angle with Known Truth X {true_result.xaxis}"
+    ), f"Model Result X {model_result.xaxis} angle discrepancy with Known Truth X {true_result.xaxis}"
     assert TOL.is_angle_zero(
         model_result.yaxis.angle(true_result.yaxis)
-    ), f"Model Result Y {model_result.yaxis} angle with Known Truth Y {true_result.yaxis}"
+    ), f"Model Result Y {model_result.yaxis} angle discrepancy with Known Truth Y {true_result.yaxis}"
 
 
 def validate_ik_with_fk(ik_target_frame, fk_result_frame):
@@ -49,10 +54,10 @@ def validate_ik_with_fk(ik_target_frame, fk_result_frame):
     ), f"IK Target Pt {ik_target_frame.point} != FK Result Pt {fk_result_frame.point}"
     assert TOL.is_angle_zero(
         ik_target_frame.xaxis.angle(fk_result_frame.xaxis)
-    ), f"IK Target X {ik_target_frame.xaxis} angle with FK Result X {fk_result_frame.xaxis} > tolerance"
+    ), f"IK Target X {ik_target_frame.xaxis} angle discrepancy with FK Result X {fk_result_frame.xaxis}"
     assert TOL.is_angle_zero(
         ik_target_frame.yaxis.angle(fk_result_frame.yaxis)
-    ), f"IK Target Y {ik_target_frame.yaxis} angle with FK Result Y {fk_result_frame.yaxis} > tolerance"
+    ), f"IK Target Y {ik_target_frame.yaxis} angle discrepancy with FK Result Y {fk_result_frame.yaxis}"
 
 
 def _test_fk_with_pybullet_planner(robot, true_result):

--- a/tests/ipy_test_runner.py
+++ b/tests/ipy_test_runner.py
@@ -12,4 +12,10 @@ if __name__ == "__main__":
     pytest.load_fake_module("Rhino")
     pytest.load_fake_module("Rhino.Geometry", fake_types=["RTree", "Sphere", "Point3d"])
 
-    pytest.run(HERE)
+    # Exclude PyBullet tests in Iron Python environment
+    exclude_list = [
+        "tests/backends/pybullet/test_pybullet_client.py",
+        "tests/backends/pybullet/test_pybullet_planner.py",
+    ]
+
+    pytest.run(HERE, exclude_list=exclude_list)

--- a/tests/robots/test_robot.py
+++ b/tests/robots/test_robot.py
@@ -83,7 +83,7 @@ def ur5_with_fake_ik(ur5_robot_instance, fake_client):
                 yield (ik[0], ik[2])
 
     ur5_robot_instance.client = fake_client
-    ur5_robot_instance.client.inverse_kinematics = FakeInverseKinematics()
+    ur5_robot_instance.client.inverse_kinematics = FakeInverseKinematics(fake_client).inverse_kinematics
 
     return ur5_robot_instance
 

--- a/tests/robots/test_targets.py
+++ b/tests/robots/test_targets.py
@@ -172,7 +172,7 @@ def test_target_scale(frame_target):
     nt = frame_target.scaled(scale_factor)
     assert nt.target_frame == frame_target.target_frame.scaled(scale_factor)
     assert nt.tolerance_position == frame_target.tolerance_position * scale_factor
-    assert nt.tolerance_orientation == frame_target.tolerance_orientation * scale_factor
+    assert nt.tolerance_orientation == frame_target.tolerance_orientation
     assert nt.tool_coordinate_frame == frame_target.tool_coordinate_frame.scaled(scale_factor)
 
 


### PR DESCRIPTION
This PR fixes a few problems I encountered while writing unit tests for PyBullet. The  problems are:

* Fixed error in `PyBulletForwardKinematics.forward_kinematics` where function would crash if `options` was not passed.
* Fixed error in `PyBulletInverseKinematics._accurate_inverse_kinematics` where threshold was not squared for comparison.


* Added `PyBulletClient.load_existing_robot` to load from an existing Robot, such as those in RobotLibrary. This makes writing tests much easier.
* Added unit test for `PyBulletClient` and `PyBulletPlanner` backend features, including Ik and FK agreement tests.

This should be reviewed after #428 and earlier PRs are merged to main.