### PR TITLE
Conditionally install pybullet if not in rhino

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Rhino CPython support: change `pybullet` to be optional requirements inside Rhino.
+
 ### Removed
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import io
+import sys
 from glob import glob
 from os import path
 
@@ -22,6 +23,12 @@ exec(read("src", "compas_fab", "__version__.py"), about)
 
 long_description = read("README.md")
 requirements = read("requirements.txt").split("\n")
+
+# Conditionally exclude pybullet if we're installing inside Rhino
+# because it fails to compile
+if "rhino" in sys.executable.lower():
+    requirements = [r for r in requirements if "pybullet" not in r]
+
 optional_requirements = {}
 
 setup(


### PR DESCRIPTION
Pybullet does not install on Rhino CPython at the moment, so, if we're installing from Rhino, it's skipping it. The loading is already conditional, with the lazy import/loader, because that's always been the case.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
