### PR TITLE
pybullet as extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Made `pybullet` entirely optional. To install `pybullet`, use `pip install compas_fab.[pybullet]` or install `pybullet` manually.
+
 ### Removed
 
 

--- a/docs/backends/pybullet.rst
+++ b/docs/backends/pybullet.rst
@@ -18,6 +18,12 @@ planning functionality.  PyBullet is also not compatible with IronPython. Hence 
 it with Rhinoceros and Grasshopper it must be invoked through the
 :mod:`compas.rpc` module.
 
+Pybullet itself is no longer a dependency of ``compas_fab``, instead it is an
+optional requirement.
+
+To install it, using ``pip install compas_fab.[pybullet]`` or install using the
+package manager of your choice.
+
 Next Steps
 ==========
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+pybullet
 attrs >=19.3.0
 black
 bump2version >=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 compas >= 2.0.4, < 3
 compas_robots >= 0.3, < 1
 roslibpy >= 1.1.0
-pybullet
 pyserial

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import io
-import sys
 from glob import glob
 from os import path
 
@@ -23,13 +22,7 @@ exec(read("src", "compas_fab", "__version__.py"), about)
 
 long_description = read("README.md")
 requirements = read("requirements.txt").split("\n")
-
-# Conditionally exclude pybullet if we're installing inside Rhino
-# because it fails to compile
-if "rhino" in sys.executable.lower():
-    requirements = [r for r in requirements if "pybullet" not in r]
-
-optional_requirements = {}
+optional_requirements = {"pybullet": ["pybullet"]}
 
 setup(
     name=about["__title__"],
@@ -64,6 +57,6 @@ setup(
     ],
     keywords=["robotic fabrication", "digital fabrication", "architecture", "robotics", "ros"],
     install_requires=requirements,
-    extras_require={},
+    extras_require=optional_requirements,
     entry_points={},
 )


### PR DESCRIPTION
Rhino is not using setup.py, so we're moving pybullet to be totally extra requirement.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
