### PR TITLE
Fix get_link_names exception for single-link groups (#160)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,3 +17,4 @@
 - Edvard Bruun <<ebruun@princeton.edu>> [@ebruun](https://github.com/ebruun)
 - Victor Pok Yin Leung <<leung@arch.ethz.ch>> [@yck011522](https://github.com/yck011522)
 - Begüm Saral <<begum.saral@tum.de>> [@begums](https://github.com/begums)
+- Swastik Verma <<swastikjee09@gmail.com>> [@Swastik-Verma](https://github.com/Swastik-Verma)

--- a/src/compas_fab/robots/robot_cell.py
+++ b/src/compas_fab/robots/robot_cell.py
@@ -450,8 +450,11 @@ class RobotCell(Data):
         base_link_name = self.get_base_link_name(group)
         end_effector_link_name = self.get_end_effector_link_name(group)
         link_names = []
-        for link in self.robot_model.iter_link_chain(base_link_name, end_effector_link_name):
-            link_names.append(link.name)
+        if base_link_name is not None and base_link_name == end_effector_link_name:
+            link_names.append(base_link_name)
+        else:
+            for link in self.robot_model.iter_link_chain(base_link_name, end_effector_link_name):
+                link_names.append(link.name)
         return link_names
 
     def get_link_names_with_collision_geometry(self) -> list[str]:

--- a/tests/robots/test_robot_cell.py
+++ b/tests/robots/test_robot_cell.py
@@ -178,6 +178,9 @@ def test_get_link_names(panda, rfl, ur10e_gripper_one_beam, abb_irb4600_40_255_g
     _test(*rfl)
     _test(*ur10e_gripper_one_beam)
     _test(*abb_irb4600_40_255_gripper_one_beam)
+    robot_cell, robot_cell_state = ur10e_gripper_one_beam
+    link_names = robot_cell.get_link_names("endeffector")
+    assert link_names == ["tool0"]
 
 
 def test_default_touch_links_returns_first_geometry_bearing_link():


### PR DESCRIPTION
Fixes #160

## Problem
`RobotCell.get_link_names()` raised an exception when called on a group
consisting of a single link (e.g. an end-effector group with no
configurable joints), instead of returning that link's name.

## Root cause
When a group's base link and end-effector link are the same (i.e. the
group has only one link), `get_link_names()` would still call
`iter_link_chain()`, which internally tries to compute a shortest path
between two identical nodes. This returns an empty path, which was
incorrectly treated as "no chain found," raising an exception even
though the group is valid.

## Fix
Added a check in `get_link_names()`: if the base link and end-effector
link are the same, the function returns that single link's name
directly, without going through the chain-finding logic.

## Testing
Added a test case in `test_get_link_names` using the `endeffector`
group on the `ur10e_gripper_one_beam` fixture, which has a single link
and zero configurable joints — reproducing the original bug scenario.
Verified the fix with:
- `invoke test --doctest`
- `invoke testcodeblocks`

Both show the same pre-existing, unrelated baseline failures as before
this change (documented in issue discussion/PR comments if needed),
with no new failures introduced.