### PR TITLE
Update 04_ik_allow_collision.py

### DIFF
--- a/docs/backends/ros/files/04_ik_allow_collision.py
+++ b/docs/backends/ros/files/04_ik_allow_collision.py
@@ -1,12 +1,7 @@
-from compas.geometry import Box
-from compas.geometry import Frame
-
-from compas_fab.backends import InverseKinematicsError
-from compas_fab.backends import MoveItPlanner
-from compas_fab.backends import RosClient
-from compas_fab.robots import FrameTarget
-from compas_fab.robots import RigidBody
-from compas_fab.robots import TargetMode
+from typing import Any, Dict
+from compas.geometry import Box, Frame
+from compas_fab.backends import InverseKinematicsError, MoveItPlanner, RosClient
+from compas_fab.robots import FrameTarget, RigidBody, TargetMode
 
 with RosClient() as client:
     planner = MoveItPlanner(client)
@@ -25,15 +20,16 @@ with RosClient() as client:
     # Create a target frame with the ROBOT mode
     frame_WCF = Frame([0.3, 0.1, 0.5], [1, 0, 0], [0, 1, 0])
     target = FrameTarget(frame_WCF, TargetMode.ROBOT)
-    print("Target frame with Robot Mode: {}".format(target))
+    print(f"Target frame with Robot Mode: {target}")
 
     # Calculate inverse kinematics
-    def calculate(options):
+    def calculate(options: Dict[str, Any]) -> None:
+        """Helper function to solve IK for the target frame and print the outcome."""
         try:
             configuration = planner.inverse_kinematics(target, start_state, options=options)
-            print("   Found configuration: ", configuration)
+            print(f"    Found configuration: {configuration}")
         except InverseKinematicsError as e:
-            print("   Failed to find a configuration: ", e)
+            print(f"    Failed to find a configuration: {e}")
 
     print("Inverse kinematics with collision check enabled: (by default)")
     calculate({})
@@ -41,12 +37,3 @@ with RosClient() as client:
     print("Inverse kinematics with collision check disabled:")
     options = {"check_collision": False}
     calculate(options)
-
-"""
-Output:
->>> Target frame with Robot Mode: FrameTarget(Frame(point=Point(x=0.300, y=0.100, z=0.500), xaxis=Vector(x=1.000, y=0.000, z=0.000), yaxis=Vector(x=0.000, y=1.000, z=0.000)), ROBOT)
->>> Inverse kinematics with collision check enabled: (by default)
->>>    Failed to find a configuration:  No inverse kinematics solution found.
->>> Inverse kinematics with collision check disabled:
->>>    Found configuration:  Configuration((-0.031, -2.025, 2.161, 4.576, -4.712, -1.540), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))
-"""

--- a/docs/backends/ros/files/04_ik_allow_collision.py
+++ b/docs/backends/ros/files/04_ik_allow_collision.py
@@ -1,7 +1,15 @@
-from typing import Any, Dict
-from compas.geometry import Box, Frame
-from compas_fab.backends import InverseKinematicsError, MoveItPlanner, RosClient
-from compas_fab.robots import FrameTarget, RigidBody, TargetMode
+from typing import Any
+from typing import Dict
+
+from compas.geometry import Box
+from compas.geometry import Frame
+
+from compas_fab.backends import InverseKinematicsError
+from compas_fab.backends import MoveItPlanner
+from compas_fab.backends import RosClient
+from compas_fab.robots import FrameTarget
+from compas_fab.robots import RigidBody
+from compas_fab.robots import TargetMode
 
 with RosClient() as client:
     planner = MoveItPlanner(client)
@@ -37,3 +45,12 @@ with RosClient() as client:
     print("Inverse kinematics with collision check disabled:")
     options = {"check_collision": False}
     calculate(options)
+
+"""
+Output:
+>>> Target frame with Robot Mode: FrameTarget(Frame(point=Point(x=0.300, y=0.100, z=0.500), xaxis=Vector(x=1.000, y=0.000, z=0.000), yaxis=Vector(x=0.000, y=1.000, z=0.000)), ROBOT)
+>>> Inverse kinematics with collision check enabled: (by default)
+>>>     Failed to find a configuration:  No inverse kinematics solution found.
+>>> Inverse kinematics with collision check disabled:
+>>>     Found configuration:  Configuration((-0.031, -2.025, 2.161, 4.576, -4.712, -1.540), (0, 0, 0, 0, 0, 0), ('shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'))
+"""


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
This PR modernizes the IK collision example script by adopting Python f-strings, adding type annotations to the helper function, and incorporating clear docstrings to improve readability and code quality.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas_fab.robots.CollisionMesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)